### PR TITLE
fix: add `allow_on_submit` for ETR fields

### DIFF
--- a/csf_ke/csf_ke/patches/patch_purchase_invoice.py
+++ b/csf_ke/csf_ke/patches/patch_purchase_invoice.py
@@ -9,6 +9,7 @@ def execute():
                 "label": "ETR Data",
                 "fieldtype": "Tab Break",
                 "insert_after": "supplied_items",
+                "allow_on_submit": True,
                 "translatable": 1
             },
             {
@@ -17,6 +18,7 @@ def execute():
                 "fieldtype": "Data",
                 "collapsible": 0,
                 "insert_after": "etr_data",
+                "allow_on_submit": True,
                 "translatable": 1
             },
             {
@@ -24,6 +26,7 @@ def execute():
                 "fieldtype": "Column Break",
                 "collapsible": 0,
                 "insert_after": "etr_serial_number",
+                "allow_on_submit": True,
                 "translatable": 1
             },
             {
@@ -32,6 +35,7 @@ def execute():
                 "fieldtype": "Data",
                 "collapsible": 0,
                 "insert_after": "etr_column_break",
+                "allow_on_submit": True,
                 "translatable": 1
             }
         ]

--- a/csf_ke/csf_ke/patches/patch_sales_invoice.py
+++ b/csf_ke/csf_ke/patches/patch_sales_invoice.py
@@ -9,6 +9,7 @@ def execute():
                 "label": "ETR Data",
                 "fieldtype": "Tab Break",
                 "insert_after": "timesheets",
+                "allow_on_submit": True,
                 "translatable": 1
             },
             {
@@ -17,6 +18,7 @@ def execute():
                 "fieldtype": "Data",
                 "collapsible": 0,
                 "insert_after": "etr_data",
+                "allow_on_submit": True,
                 "translatable": 1
             },
             {
@@ -24,6 +26,7 @@ def execute():
                 "fieldtype": "Column Break",
                 "collapsible": 0,
                 "insert_after": "etr_serial_number",
+                "allow_on_submit": True,
                 "translatable": 1
             },
             {
@@ -32,6 +35,7 @@ def execute():
                 "fieldtype": "Data",
                 "collapsible": 0,
                 "insert_after": "etr_column_break",
+                "allow_on_submit": True,
                 "translatable": 1
             }
         ]

--- a/csf_ke/patches.txt
+++ b/csf_ke/patches.txt
@@ -1,4 +1,4 @@
-csf_ke.csf_ke.patches.patch_sales_invoice #19 June 2023 12:53
-csf_ke.csf_ke.patches.patch_purchase_invoice #20 June 2023 10:05
+csf_ke.csf_ke.patches.patch_sales_invoice #26 June 2023 19:24
+csf_ke.csf_ke.patches.patch_purchase_invoice #26 June 2023 19:28
 csf_ke.csf_ke.patches.patch_employee #20 June 2023 08:26
 csf_ke.csf_ke.patches.patch_delete_employee_unnecessary_fields #20 June 2023 08:25


### PR DESCRIPTION
Allow ETR fields to be edited even after documents are submitted: `Sales Invoice` and `Purchase Invoice`