### PR TITLE
(fix): Add items child table to 

### DIFF
--- a/csf_ke/csf_ke/doctype/api/update_item_price_list.py
+++ b/csf_ke/csf_ke/doctype/api/update_item_price_list.py
@@ -20,7 +20,6 @@ def update_item_prices(doc, method):
 
     # Fetch margin entries based on the currency and buying price list
     margin_entries = get_margin_entries_and_details(currency, price_list)
-    # frappe.throw(str(margin_entries))
     if not margin_entries:
         frappe.log_error(f"No margin entries found for currency {currency} and buying price list {price_list}")
         return
@@ -31,8 +30,6 @@ def update_item_prices(doc, method):
 
         # Fetch applicable margins for the item
         applicable_margins = margin_lookup.get(item.item_code, [])
-        print(f"__________________________ Applicable margins: _____________________ {str(applicable_margins)} for item {item.item_code}")
-        # frappe.throw(str(applicable_margins))
 
         if not applicable_margins:
             frappe.log_error(f"No applicable margins found for item {item.item_code}")
@@ -40,31 +37,17 @@ def update_item_prices(doc, method):
 
         for margin_entry in applicable_margins:
             selling_price_list = margin_entry['selling_price']
-            # frappe.throw(str(margin_entry))
-            print(f"selling_price_list: {selling_price_list}")
-            # frappe.throw(str(selling_price_list))
-
-            # Fetch margin details for the selling price list
-            # margin_details = get_margin_details(selling_price_list)
-            # print(f"margin_details: {margin_details}")
-            # frappe.throw(str(margin_details))
-
-            # if not margin_details:
-            #     frappe.log_error(f"No margin details found for selling price list {selling_price_list}")
-            #     continue
 
             new_rate = calculate_new_rate(item.rate, margin_entry)
 
             # Check if the item already has an item price for the selling price list
             existing_item_price = check_existing_item_price(item.item_code, selling_price_list, item.uom)
-            # frappe.throw(str(existing_item_price))
 
             # Update or create price list based on the fetched margins
             if existing_item_price:
                 if margin_entry.get("new_selling_price_list", False):
                     # Create a new price list
                     create_and_process_new_price_list(item, selling_price_list, margin_entry, currency)
-                    print(f"____________________ Item price updated for item {item.item_code} and selling price list {selling_price_list}")
                 
                 elif margin_entry.get("update_existing_price_list", False):
                     # Validate batch_no and date range before updating
@@ -73,14 +56,10 @@ def update_item_prices(doc, method):
                         existing_item_price.get("valid_upto")
                     ):
                         process_existing_price_list(item, selling_price_list, margin_entry, existing_item_price['price_list_rate'])
-                        print(f"____________________ Item price updated for item {item.item_code} and selling price list {selling_price_list}")
             elif existing_item_price is None:
                 create_and_process_new_price_list(item, selling_price_list, margin_entry, currency)
-                print(f"____________________ Item price updated for item {item.item_code} and selling price list {selling_price_list}")
             else:
                 frappe.log_error(f"No margin details found for selling price list {selling_price_list}")
-
-    # frappe.throw(str(applicable_margins_res))
     
 
 def get_margin_entries_and_details(currency, price_list):
@@ -142,21 +121,6 @@ def build_margin_lookup(margin_entries):
     
     return margin_lookup
 
-# def get_margin_details(selling_price_list):
-#     """
-#     Retrieve margin details for a given selling price list from Selling Item Price Margin.
-
-#     Args:
-#         selling_price_list (str): The selling price list to fetch margin details for.
-
-#     Returns:
-#         dict: Dictionary containing margin details or None if not found.
-#     """
-#     return frappe.get_all(
-#         "Selling Item Price Margin",
-#         {"selling_price": selling_price_list, "disabled": 0, "docstatus": 1},
-#         ["margin_based_on", "margin_type", "margin_percentage_or_amount", "buying_price", "update_existing_price_list", "new_selling_price_list"]
-#     )
 
 def check_existing_item_price(item_code, price_list, uom):
     """

--- a/csf_ke/csf_ke/doctype/api/update_item_price_list.py
+++ b/csf_ke/csf_ke/doctype/api/update_item_price_list.py
@@ -88,7 +88,6 @@ def get_margin_entries_and_details(currency, price_list):
     )
 
     if not margins:
-        print(f"No margin entries found for currency {currency}, buying price list {price_list}")
         return []
 
     # Fetch associated items for each margin

--- a/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.js
+++ b/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.js
@@ -2,14 +2,22 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Selling Item Price Margin", {
-  refresh(frm) {},
-  update_existing_price_list: function(frm) {
-        if (frm.doc.update_existing_price_list) {
-            frm.set_value('new_selling_price_list', 0);
-        } else {
-            frm.set_value('new_selling_price_list', 1);
-        }
+    refresh(frm) {},
+
+    before_save(frm) {
+        adjust_margin_field_type(frm);
     },
+
+    before_submit(frm) {
+        adjust_margin_field_type(frm);
+    },
+    update_existing_price_list: function(frm) {
+            if (frm.doc.update_existing_price_list) {
+                frm.set_value('new_selling_price_list', 0);
+            } else {
+                frm.set_value('new_selling_price_list', 1);
+            }
+        },
     new_selling_price_list: function(frm) {
         if (frm.doc.new_selling_price_list) {
             frm.set_value('update_existing_price_list', 0);
@@ -18,30 +26,34 @@ frappe.ui.form.on("Selling Item Price Margin", {
         }
     },
     margin_type: function(frm) {
-        if (frm.doc.margin_type === "Amount") {
-            frm.set_df_property('margin_percentage_or_amount', 'fieldtype', 'Currency');
-            frm.refresh_field('margin_percentage_or_amount');
-        } else if (frm.doc.margin_type === "Percentage") {
-            frm.set_df_property('margin_percentage_or_amount', 'fieldtype', 'Percent');
-            frm.refresh_field('margin_percentage_or_amount');
-        }
+        adjust_margin_field_type(frm);
     },
-  onload: function (frm) {
-    frm.set_query("selling_price", function () {
-      return {
-        filters: {
-          selling: 1,
-          currency: frm.doc.currency,
-        },
-      };
-    });
-    frm.set_query("buying_price", function () {
-      return {
-        filters: {
-          buying: 1,
-          currency: frm.doc.currency,
-        },
-      };
-    });
-  },
+
+    onload: function (frm) {
+        frm.set_query("selling_price", function () {
+        return {
+            filters: {
+            selling: 1,
+            currency: frm.doc.currency,
+            },
+        };
+        });
+        frm.set_query("buying_price", function () {
+        return {
+            filters: {
+            buying: 1,
+            currency: frm.doc.currency,
+            },
+        };
+        });
+    },
 });
+
+function adjust_margin_field_type(frm) {
+    if (frm.doc.margin_type === "Amount") {
+        frm.set_df_property('margin_percentage_or_amount', 'fieldtype', 'Currency');
+    } else if (frm.doc.margin_type === "Percentage") {
+        frm.set_df_property('margin_percentage_or_amount', 'fieldtype', 'Percent');
+    }
+    frm.refresh_field('margin_percentage_or_amount');
+}

--- a/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.json
+++ b/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.json
@@ -26,6 +26,8 @@
   "margin_type",
   "column_break_xxgj",
   "margin_percentage_or_amount",
+  "section_break_ovfi",
+  "items",
   "section_break_hbod",
   "amended_from"
  ],
@@ -64,8 +66,7 @@
    "fieldname": "end_date",
    "fieldtype": "Date",
    "in_list_view": 1,
-   "label": "End Date",
-   "reqd": 1
+   "label": "End Date"
   },
   {
    "fieldname": "column_break_zujf",
@@ -96,7 +97,7 @@
    "fieldname": "margin_based_on",
    "fieldtype": "Select",
    "label": "Margin Based On",
-   "options": "\nBuying Price",
+   "options": "Buying Price",
    "reqd": 1
   },
   {
@@ -115,7 +116,7 @@
    "fieldname": "margin_type",
    "fieldtype": "Select",
    "label": "Margin Type",
-   "options": "\nAmount\nPercentage",
+   "options": "Amount\nPercentage",
    "reqd": 1
   },
   {
@@ -160,12 +161,22 @@
    "fieldname": "new_selling_price_list",
    "fieldtype": "Check",
    "label": "New Selling Price List"
+  },
+  {
+   "fieldname": "section_break_ovfi",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "items",
+   "fieldtype": "Table",
+   "label": "Items",
+   "options": "Selling Item Price Margin Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-29 15:26:13.458907",
+ "modified": "2024-12-12 18:22:57.376409",
  "modified_by": "Administrator",
  "module": "CSF KE",
  "name": "Selling Item Price Margin",

--- a/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.json
+++ b/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.json
@@ -52,6 +52,7 @@
    "label": "Duration"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "start_date",
    "fieldtype": "Date",
    "in_list_view": 1,
@@ -63,6 +64,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "end_date",
    "fieldtype": "Date",
    "in_list_view": 1,
@@ -121,6 +123,7 @@
    "reqd": 1
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "margin_percentage_or_amount",
    "fieldtype": "Currency",
    "label": "Margin Percentage or Amount",
@@ -168,6 +171,8 @@
    "fieldtype": "Section Break"
   },
   {
+   "allow_bulk_edit": 1,
+   "allow_on_submit": 1,
    "fieldname": "items",
    "fieldtype": "Table",
    "label": "Items",
@@ -177,7 +182,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-12 20:54:17.817519",
+ "modified": "2024-12-16 12:20:23.161007",
  "modified_by": "Administrator",
  "module": "CSF KE",
  "name": "Selling Item Price Margin",
@@ -202,5 +207,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.json
+++ b/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.json
@@ -105,7 +105,8 @@
    "fieldname": "buying_price",
    "fieldtype": "Link",
    "label": "Buying Price",
-   "options": "Price List"
+   "options": "Price List",
+   "reqd": 1
   },
   {
    "fieldname": "section_break_ozli",
@@ -176,7 +177,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-12 18:22:57.376409",
+ "modified": "2024-12-12 20:54:17.817519",
  "modified_by": "Administrator",
  "module": "CSF KE",
  "name": "Selling Item Price Margin",

--- a/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.json
+++ b/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.json
@@ -12,8 +12,8 @@
   "end_date",
   "column_break_zujf",
   "disabled",
-  "new_selling_price_list",
-  "update_existing_price_list",
+  "section_break_sakr",
+  "price_list_action",
   "section_break_mayg",
   "selling_price",
   "column_break_lymo",
@@ -155,18 +155,6 @@
    "reqd": 1
   },
   {
-   "default": "0",
-   "fieldname": "update_existing_price_list",
-   "fieldtype": "Check",
-   "label": "Update Existing Price List"
-  },
-  {
-   "default": "1",
-   "fieldname": "new_selling_price_list",
-   "fieldtype": "Check",
-   "label": "New Selling Price List"
-  },
-  {
    "fieldname": "section_break_ovfi",
    "fieldtype": "Section Break"
   },
@@ -177,12 +165,24 @@
    "fieldtype": "Table",
    "label": "Items",
    "options": "Selling Item Price Margin Item"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "price_list_action",
+   "fieldtype": "Select",
+   "label": "Price List Action",
+   "options": "New Selling Price List\nUpdate Existing Price List"
+  },
+  {
+   "fieldname": "section_break_sakr",
+   "fieldtype": "Section Break",
+   "label": "Price List Action"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-16 12:20:23.161007",
+ "modified": "2024-12-17 12:02:20.417949",
  "modified_by": "Administrator",
  "module": "CSF KE",
  "name": "Selling Item Price Margin",

--- a/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.py
+++ b/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.py
@@ -11,14 +11,27 @@ class SellingItemPriceMargin(Document):
     def before_save(self):
 
         self.check_date_overlap()
+        self.validate_margin_field()
 
     def on_update(self):
 
         self.check_date_overlap()
+        self.validate_margin_field()
 
     def on_update_after_submit(self):
 
         self.check_date_overlap()
+        self.validate_margin_field()
+
+    def validate_margin_field(self):
+
+        if self.margin_type == "Amount":
+            if self.margin_percentage_or_amount < 0:
+                frappe.throw(_("Margin Amount cannot be negative."))
+
+        elif self.margin_type == "Percentage":
+            if self.margin_percentage_or_amount < 0 or self.margin_percentage_or_amount > 100:
+                frappe.throw(_("Margin Percentage must be between 0 and 100."))
 
     def check_date_overlap(self):
 

--- a/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.py
+++ b/csf_ke/csf_ke/doctype/selling_item_price_margin/selling_item_price_margin.py
@@ -12,12 +12,31 @@ class SellingItemPriceMargin(Document):
 
         self.check_date_overlap()
 
+    def on_update(self):
+
+        self.check_date_overlap()
+
+    def on_update_after_submit(self):
+
+        self.check_date_overlap()
+
     def check_date_overlap(self):
+
+        item_codes = [item.item_code for item in self.items]
+        duplicate_items = [item for item in set(item_codes) if item_codes.count(item) > 1]
+
+        if duplicate_items:
+            frappe.throw(
+                title=_("Duplicate Items"),
+                msg=_("{0}").format(", ".join(duplicate_items)),
+                exc=frappe.DuplicateEntryError,
+            )
 
         existing_records = frappe.get_all(
             "Selling Item Price Margin",
             filters={
                 "docstatus": 1,
+                "disabled": 0,
                 "selling_price": self.selling_price,
                 "name": ("!=", self.name),
                 "start_date": ("<=", self.start_date),

--- a/csf_ke/csf_ke/doctype/selling_item_price_margin_item/selling_item_price_margin_item.json
+++ b/csf_ke/csf_ke/doctype/selling_item_price_margin_item/selling_item_price_margin_item.json
@@ -1,0 +1,70 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-12-12 17:08:58.595321",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "item_code",
+  "item_group",
+  "column_break_vstq",
+  "item_name",
+  "uom"
+ ],
+ "fields": [
+  {
+   "columns": 4,
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Item Code",
+   "options": "Item",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_vstq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "item_code.item_name",
+   "fieldname": "item_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_preview": 1,
+   "label": "Item Name"
+  },
+  {
+   "fetch_from": "item_code.item_group",
+   "fieldname": "item_group",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "label": "Item Group",
+   "options": "Item Group"
+  },
+  {
+   "fetch_from": "item_code.stock_uom",
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "label": "UOM",
+   "options": "UOM"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-12-12 17:18:09.505946",
+ "modified_by": "Administrator",
+ "module": "CSF KE",
+ "name": "Selling Item Price Margin Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/csf_ke/csf_ke/doctype/selling_item_price_margin_item/selling_item_price_margin_item.json
+++ b/csf_ke/csf_ke/doctype/selling_item_price_margin_item/selling_item_price_margin_item.json
@@ -7,9 +7,9 @@
  "engine": "InnoDB",
  "field_order": [
   "item_code",
-  "item_group",
-  "column_break_vstq",
   "item_name",
+  "column_break_vstq",
+  "item_group",
   "uom"
  ],
  "fields": [
@@ -34,7 +34,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_preview": 1,
-   "label": "Item Name"
+   "label": "Item Name",
+   "read_only": 1
   },
   {
    "fetch_from": "item_code.item_group",
@@ -43,7 +44,8 @@
    "in_filter": 1,
    "in_list_view": 1,
    "label": "Item Group",
-   "options": "Item Group"
+   "options": "Item Group",
+   "read_only": 1
   },
   {
    "fetch_from": "item_code.stock_uom",
@@ -52,13 +54,14 @@
    "in_filter": 1,
    "in_list_view": 1,
    "label": "UOM",
-   "options": "UOM"
+   "options": "UOM",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-12-12 17:18:09.505946",
+ "modified": "2024-12-16 16:21:53.264727",
  "modified_by": "Administrator",
  "module": "CSF KE",
  "name": "Selling Item Price Margin Item",

--- a/csf_ke/csf_ke/doctype/selling_item_price_margin_item/selling_item_price_margin_item.py
+++ b/csf_ke/csf_ke/doctype/selling_item_price_margin_item/selling_item_price_margin_item.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Navari Ltd and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class SellingItemPriceMarginItem(Document):
+	pass


### PR DESCRIPTION
# Update Item Price List

The `update_item_price_list.py` script enhances the functionality of setting and updating item prices based on profit margins derived from specific price lists and cost metrics. This document outlines the functionality and setup required to use this script effectively.

## Features

- **Custom Profit Margins**: Users can specify a profit margin based on either the valuation rate or the buying price of items.
- **Flexible Profit Types**: Choose to add a profit margin as a fixed amount or a percentage.
- **Price List Selection**: Users Select Buying price lists to calculate the desired selling price.
- **Automatic Price List Creation**: For items not previously listed, the script will create a new item price list entry of type selling with the calculated price or update the rate of the already existing price list.

## Workflow

1. **Set the Duration Period**: That is the duration for when the Selling Item Price Margin Rule will take effect. E.g., Start Date: 01-01-2024 to End Date: 31-12-2024

![image](https://github.com/user-attachments/assets/c3531ffb-2083-4a22-a856-b441f5b60a59)

2. **Set the Price List Action**:  Whether you want new Item Prices to be created or to update the already existing Item Prices.

![image](https://github.com/user-attachments/assets/9e5ef4b7-b24b-4d88-98f4-27e309becbbf)

3. **Select Selling Price List**: Start by choosing a Selling Price from price list from which you want to derive profit margins.

![image](https://github.com/user-attachments/assets/38fca4e4-a303-46d8-b01e-55773c6bbf71)

4. **Select Buying Price List for the Profit Margin Basis**:

![image](https://github.com/user-attachments/assets/b5c68dd1-924c-41ce-afe7-e1c0eca11428)

5. **Define Profit Margin**: Price Margin Value Section

   - Specify the profit margin type (Amount or Percentage).
   
![image](https://github.com/user-attachments/assets/3fb85661-5edb-4c02-ad3e-3758f426cfdb)

   - Enter the value of the profit margin.

![image](https://github.com/user-attachments/assets/dfc8df28-6a28-4950-bf9f-a0793281ca24)

6. **Specify the Items Margin Should be Applied To**: In the Items child table you can specify the Items for which you want the Profit to be assigned. N/B: An Item cannot be in two Docs with active start and end date.

![image](https://github.com/user-attachments/assets/687c4aeb-6520-4d6d-b43a-8a393d2b976c)

7. **Execution**:

   - Upon submission of a purchase receipt or purchase invoice (N/B with update_stock being true), the script calculates the new item selling price by adding the specified profit margin to the item's base cost.
