### PR TITLE
Add Payment Allocation Option for VAT Withholding When Amounts Match

### DIFF
--- a/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.js
+++ b/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.js
@@ -24,5 +24,16 @@ frappe.ui.form.on("VAT Withholding", {
                 );
             });
         }
+    },
+
+    company(frm) {
+        frm.set_query("voucher_no", function () {
+            return {
+                filters: {
+                    docstatus: 1,
+                    company: frm.doc.company,
+                },
+            };
+        });
     }
 });

--- a/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.js
+++ b/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.js
@@ -2,24 +2,27 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("VAT Withholding", {
-	before_submit(frm) {
+    before_submit(frm) {
+
         if (frm.doc.vat_withholding_amount === frm.doc.outstanding_amount && !frm.doc.allocate_payment) {
-            if (!frm.__confirmed_allocation) {
+            
+            return new Promise((resolve) => {
                 frappe.confirm(
-                    __("Would you like to allocate payment to the Journal Entry for this VAT Withholding?"),
+                    __("The Withholding Amount ({0}) equals the Outstanding Amount ({1}). Would you like to allocate payment to the Journal Entry for Sales Invoice {2}?", 
+                        [frm.doc.vat_withholding_amount, frm.doc.outstanding_amount, frm.doc.voucher_no]),
                     () => {
+
                         frm.set_value("allocate_payment", 1);
-                        frm.__confirmed_allocation = true;
-                        frm.savesubmit();
+                        frm.save('Submit');
+                        frm.refresh();
+                        
                     },
                     () => {
-                        frm.__confirmed_allocation = true;
-                        frm.savesubmit();
+                        frm.save('Submit');
+                        frm.refresh();
                     }
                 );
-            }
-            
-            frappe.validated = false;
+            });
         }
-	}
+    }
 });

--- a/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.js
+++ b/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.js
@@ -1,8 +1,25 @@
 // Copyright (c) 2025, Navari Ltd and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("VAT Withholding", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("VAT Withholding", {
+	before_submit(frm) {
+        if (frm.doc.vat_withholding_amount === frm.doc.outstanding_amount && !frm.doc.allocate_payment) {
+            if (!frm.__confirmed_allocation) {
+                frappe.confirm(
+                    __("Would you like to allocate payment to the Journal Entry for this VAT Withholding?"),
+                    () => {
+                        frm.set_value("allocate_payment", 1);
+                        frm.__confirmed_allocation = true;
+                        frm.savesubmit();
+                    },
+                    () => {
+                        frm.__confirmed_allocation = true;
+                        frm.savesubmit();
+                    }
+                );
+            }
+            
+            frappe.validated = false;
+        }
+	}
+});

--- a/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.json
+++ b/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.json
@@ -13,6 +13,7 @@
   "column_break_ynaf",
   "currency",
   "withholding_account",
+  "allocate_payment",
   "section_break_onfc",
   "withholder_pin",
   "withholdee_pin",
@@ -26,6 +27,7 @@
   "column_break_tsyd",
   "wht_certificate_no",
   "pay_point_name",
+  "outstanding_amount",
   "section_break_weug",
   "vat_withholding_amount",
   "column_break_xcti",
@@ -182,6 +184,20 @@
    "fieldtype": "Link",
    "label": "Journal Entry",
    "options": "Journal Entry"
+  },
+  {
+   "fetch_from": "voucher_no.outstanding_amount",
+   "fieldname": "outstanding_amount",
+   "fieldtype": "Currency",
+   "label": "Outstanding Amount",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.vat_withholding_amount == doc.outstanding_amount",
+   "fieldname": "allocate_payment",
+   "fieldtype": "Check",
+   "label": "Allocate Payment"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -192,7 +208,7 @@
    "link_fieldname": "cheque_no"
   }
  ],
- "modified": "2025-02-21 14:50:08.071401",
+ "modified": "2025-03-05 19:42:45.064530",
  "modified_by": "Administrator",
  "module": "CSF KE",
  "name": "VAT Withholding",
@@ -200,6 +216,8 @@
  "owner": "Administrator",
  "permissions": [
   {
+   "amend": 1,
+   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,

--- a/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py
+++ b/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py
@@ -16,13 +16,16 @@ class VATWithholding(Document):
 		self.company = frappe.defaults.get_user_default("Company")
 		self.customer = frappe.get_value("Customer", {'tax_id': self.withholder_pin}, "name")
 		self.voucher_no = frappe.get_value("Sales Invoice", {'etr_invoice_number': self.invoice_no}, "name")
+		self.outstanding_amount = frappe.get_value("Sales Invoice", self.voucher_no, "outstanding_amount")
 		self.withholding_account = frappe.get_value("Company", self.company, "default_debitors_withholding_account")
 
 	def on_submit(self):
 		if not self.withholding_account:
 			frappe.throw("Please set the withholding account")
 		
-		journal_entry = self.create_journal_entry(self, "on_submit", submit_journal_entry=self.submit_journal_entry)
+		journal_entry = self.create_journal_entry(
+				self, "on_submit", submit_journal_entry=self.submit_journal_entry, allocate_payment=self.allocate_payment
+			)
 
 		frappe.db.set_value("VAT Withholding", self.name, "journal_entry", journal_entry)
 
@@ -31,6 +34,12 @@ class VATWithholding(Document):
 
 		customer_receivable_account = frappe.get_value("Company", doc.company, "default_receivable_account")
 
+		reference_doctype = "Sales Invoice" if kwargs.get("allocate_payment") else ""
+		reference_name = doc.voucher_no if kwargs.get("allocate_payment") else ""
+		remark = f"Payment for Sales Invoice {doc.voucher_no} via VAT Withholding {doc.wht_certificate_no}"\
+			  		if kwargs.get("allocate_payment")\
+					else f"VAT Withholding Acknowledgment - Cert No: {doc.wht_certificate_no}"
+
 		je = frappe.get_doc({
 			"doctype": "Journal Entry",
 			"posting_date": doc.certificate_date,
@@ -38,7 +47,7 @@ class VATWithholding(Document):
 			"voucher_type": "Journal Entry",
 			"cheque_no": doc.wht_certificate_no,
 			"cheque_date": doc.certificate_date,
-			"remark": f"VAT Withholding Acknowledgment - Cert No: {doc.wht_certificate_no}",
+			"remark": remark,
 			"accounts": [
 				{
 					"account": doc.withholding_account,
@@ -53,6 +62,8 @@ class VATWithholding(Document):
 					"credit_in_account_currency": doc.vat_withholding_amount,
 					"party_type": "Customer",
 					"party": doc.customer,
+					"reference_type": reference_doctype,
+					"reference_name": reference_name,
 				}
 			]
 		})


### PR DESCRIPTION
## Overview
This pull request introduces a new feature to the `VAT Withholding` doctype: an option to allocate the VAT withholding amount as a payment for the associated `Sales Invoice` when the `vat_withholding_amount` equals the `outstanding_amount`. 
This enhances usability by prompting users to decide whether to link the withholding journal entry to the invoice, streamlining payment reconciliation.

## Changes Made

1. **New Fields:**
   - **Outstanding Amount:** Sales Invoice's Outstanding amount
   -  **Allocate Payment: ** Check field that's only visible if `vat_wht` equals `outstanding_amount`
   
![image](https://github.com/user-attachments/assets/6d3e0377-9b7f-4e8e-bc3f-3f5fa14fc91d)

2. **New Feature: Payment Allocation Prompt**
   - **Client Script (`vat_withholding.js`)**:
   - Added a `before_submit` hook to check if `vat_withholding_amount` equals `outstanding_amount` and `allocate_payment` is unchecked.
     - Displays a confirmation dialog asking users if they want to allocate the withholding as a payment for the `Sales Invoice` referenced by `voucher_no`.
     - If "Yes" is selected, sets `allocate_payment` to `1` before submission; if "No," submits without changes.
     - Uses a `Promise` to ensure proper submission flow control.

![image](https://github.com/user-attachments/assets/728d41ec-a41b-410f-8d77-8a07261477af)

3. **Server-Side Logic Enhancement (`vat_withholding.py`)**:
   - Updated `create_journal_entry` to conditionally set `reference_type="Sales Invoice"` and `reference_name=voucher_no` in the journal entry when `allocate_payment` is `True`.
   - Modified `on_submit` to pass `allocate_payment` to `create_journal_entry`, ensuring the user’s choice is reflected in the journal entry.
   - Enhanced `set_missing_values` to populate all mandatory fields with defaults or fetched values, reducing the risk of submission failures.

![image](https://github.com/user-attachments/assets/2eed7626-d6ce-4972-8995-6f3a178d44c8)

![image](https://github.com/user-attachments/assets/652d5748-d7f3-4a30-9301-8e704bbeea68)

