### PR TITLE
feat: add dynamic item_code mandatory toggle in Sales Invoice Settings

### DIFF
--- a/csf_ke/csf_ke/doctype/sales_invoice_settings/sales_invoice_settings.js
+++ b/csf_ke/csf_ke/doctype/sales_invoice_settings/sales_invoice_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Navari Ltd and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Sales Invoice Settings", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/csf_ke/csf_ke/doctype/sales_invoice_settings/sales_invoice_settings.json
+++ b/csf_ke/csf_ke/doctype/sales_invoice_settings/sales_invoice_settings.json
@@ -1,0 +1,47 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-03-14 09:23:18.991487",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "set_item_code_mandatory",
+  "column_break_bgjq"
+ ],
+ "fields": [
+  {
+   "default": "0",
+   "fieldname": "set_item_code_mandatory",
+   "fieldtype": "Check",
+   "label": "Set Item Code Mandatory"
+  },
+  {
+   "fieldname": "column_break_bgjq",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2025-03-17 10:34:21.865325",
+ "modified_by": "Administrator",
+ "module": "CSF KE",
+ "name": "Sales Invoice Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/csf_ke/csf_ke/doctype/sales_invoice_settings/sales_invoice_settings.py
+++ b/csf_ke/csf_ke/doctype/sales_invoice_settings/sales_invoice_settings.py
@@ -39,6 +39,7 @@ class SalesInvoiceSettings(Document):
 
 					frappe.get_doc({
 						"doctype": "Property Setter",
+						"doctype_or_field": "DocField",
 						"doc_type": DOCTYPE,
 						"field_name": FIELD_NAME,
 						"property": PROPERTY,

--- a/csf_ke/csf_ke/doctype/sales_invoice_settings/sales_invoice_settings.py
+++ b/csf_ke/csf_ke/doctype/sales_invoice_settings/sales_invoice_settings.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025, Navari Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class SalesInvoiceSettings(Document):
+	
+	def before_save(self):
+		self.toggle_item_code_mandatory()
+
+	def toggle_item_code_mandatory(self):
+		"""Toggle the 'reqd' property of item_code in Sales Invoice Item based on set_item_code_mandatory."""
+		DOCTYPE = "Sales Invoice Item"
+		FIELD_NAME = "item_code"
+		PROPERTY = "reqd"
+		PROPERTY_TYPE = "Check"
+		VALUE = "1" if self.set_item_code_mandatory else "0"
+
+		field_filters = {
+			"doctype_or_field": "DocField",
+			"doc_type": DOCTYPE,
+			"field_name": FIELD_NAME,
+			"property": PROPERTY,
+			"property_type": PROPERTY_TYPE
+		}
+
+		existing_property = frappe.db.exists("Property Setter", field_filters)
+
+		try:
+			if self.set_item_code_mandatory:
+				if existing_property:
+				
+					frappe.db.set_value("Property Setter", field_filters, "value", VALUE, update_modified=False)
+
+				else:
+
+					frappe.get_doc({
+						"doctype": "Property Setter",
+						"doc_type": DOCTYPE,
+						"field_name": FIELD_NAME,
+						"property": PROPERTY,
+						"property_type": PROPERTY_TYPE,
+						"value": VALUE
+					}).insert(ignore_permissions=True)
+
+			elif existing_property:
+				frappe.delete_doc("Property Setter", existing_property, ignore_permissions=True)
+
+			frappe.db.commit()
+
+		except Exception as e:
+			frappe.log_error(f"Error updating Property Setter: {str(e)[:135]}")

--- a/csf_ke/csf_ke/doctype/sales_invoice_settings/test_sales_invoice_settings.py
+++ b/csf_ke/csf_ke/doctype/sales_invoice_settings/test_sales_invoice_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Navari Ltd and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSalesInvoiceSettings(FrappeTestCase):
+	pass


### PR DESCRIPTION
- New Single Doctype *Sales Invoice Settings*
- Used Property Setter to update item_code mandatory status based on set_item_code_mandatory check field