### PR TITLE
fix: update voucher number retrieval logic in VAT Withholding Doctype

### DIFF
--- a/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py
+++ b/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py
@@ -15,7 +15,7 @@ class VATWithholding(Document):
 		self.currency = "KES"
 		self.company = frappe.defaults.get_user_default("Company")
 		self.customer = frappe.get_value("Customer", {'tax_id': self.withholder_pin}, "name")
-		self.voucher_no = frappe.get_value("Sales Invoice", {'etr_invoice_number': self.invoice_no}, "name") or frappe.get_value("Sales Invoice", {'invoice_no': self.invoice_no}, "name")
+		self.voucher_no = frappe.get_value("Sales Invoice", {'name': self.invoice_no}, "name") or frappe.get_value("Sales Invoice", {'invoice_no': self.invoice_no}, "name")
 		self.outstanding_amount = frappe.get_value("Sales Invoice", self.voucher_no, "outstanding_amount")
 		self.withholding_account = frappe.get_value("Company", self.company, "default_debitors_withholding_account")
 		

--- a/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py
+++ b/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py
@@ -15,7 +15,7 @@ class VATWithholding(Document):
 		self.currency = "KES"
 		self.company = frappe.defaults.get_user_default("Company")
 		self.customer = frappe.get_value("Customer", {'tax_id': self.withholder_pin}, "name")
-		self.voucher_no = frappe.get_value("Sales Invoice", {'name': self.invoice_no}, "name") or frappe.get_value("Sales Invoice", {'invoice_no': self.invoice_no}, "name")
+		self.voucher_no = frappe.get_value("Sales Invoice", {'etr_invoice_number': self.invoice_no}, "name") or frappe.get_value("Sales Invoice", {'name': self.invoice_no}, "name")
 		self.outstanding_amount = frappe.get_value("Sales Invoice", self.voucher_no, "outstanding_amount")
 		self.withholding_account = frappe.get_value("Company", self.company, "default_debitors_withholding_account")
 		

--- a/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py
+++ b/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py
@@ -15,7 +15,7 @@ class VATWithholding(Document):
 		self.currency = "KES"
 		self.company = frappe.defaults.get_user_default("Company")
 		self.customer = frappe.get_value("Customer", {'tax_id': self.withholder_pin}, "name")
-		self.voucher_no = frappe.get_value("Sales Invoice", {'etr_invoice_number': self.invoice_no}, "name")
+		self.voucher_no = frappe.get_value("Sales Invoice", {'etr_invoice_number': self.invoice_no}, "name") or frappe.get_value("Sales Invoice", {'invoice_no': self.invoice_no}, "name")
 		self.outstanding_amount = frappe.get_value("Sales Invoice", self.voucher_no, "outstanding_amount")
 		self.withholding_account = frappe.get_value("Company", self.company, "default_debitors_withholding_account")
 		


### PR DESCRIPTION
This pull request includes a small but important change to the `set_missing_values` method in the `vat_withholding.py` file. The change enhances the logic for retrieving the `voucher_no` by adding a fallback query to ensure it is correctly fetched even if the first query fails.

* [`csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py`](diffhunk://#diff-d4f6495e74a9aca3fec3e53c4a066b0622adbdd439b0dca165c14b6dbbccbe7fL18-R18): Updated the `voucher_no` assignment to include a fallback query using the `invoice_no` field if the `etr_invoice_number` field does not return a result.