### PR TITLE
fix: adds required apps to the hooks.py file

### DIFF
--- a/csf_ke/hooks.py
+++ b/csf_ke/hooks.py
@@ -13,7 +13,7 @@ app_icon = "drag"
 app_color = "grey"
 app_email = "support@navari.co.ke"
 app_license = "GNU General Public License (v3)"
-required_apps = ["frappe/erpnext"]
+required_apps = ["erpnext", "hrms"]
 
 
 fixtures = [


### PR DESCRIPTION
- Ensures anyone who installs the application first installs or has ERPNext and Frappe HR applications already installed in their site.