### PR TITLE
fix(pin-validation): update KRA PIN mandatory field options and logic

### DIFF
--- a/csf_ke/csf_ke/overrides/validate_pin.py
+++ b/csf_ke/csf_ke/overrides/validate_pin.py
@@ -7,7 +7,6 @@ def validate_pin(doctype: Document, customer: Document) -> None:
     is_kra_mandatory = frappe.get_value(
         "Customer Group", customer.customer_group, "custom_is_kra_pin_mandatory_in"
     )
-
     if not is_kra_mandatory:
         return
 
@@ -17,9 +16,10 @@ def validate_pin(doctype: Document, customer: Document) -> None:
         "Sales Invoice": ["Sales Invoice", "All", "Sales Order and Invoice"],
     }
 
+    doctype_name = doctype.doctype
     if (
-        doctype.doctype not in applicable_doctypes
-        or is_kra_mandatory not in applicable_doctypes[doctype.doctype]
+        doctype_name not in applicable_doctypes
+        or not any(option.lower() == is_kra_mandatory.lower() for option in applicable_doctypes[doctype_name])
     ):
         return
 

--- a/csf_ke/fixtures/custom_field.json
+++ b/csf_ke/fixtures/custom_field.json
@@ -95,7 +95,7 @@
   "name": "Customer Group-custom_is_kra_pin_mandatory_in",
   "no_copy": 0,
   "non_negative": 0,
-  "options": "\nCustomer\nSales Order\nSales Invoice\nSales order and Invoice\nAll",
+  "options": "\nCustomer\nSales Order\nSales Invoice\nSales Order and Invoice\nAll",
   "permlevel": 0,
   "placeholder": null,
   "precision": "",


### PR DESCRIPTION

This pull request introduces changes to improve the validation of KRA PIN requirements and corrects a minor typo in the custom field options. The key updates include refining the logic for checking applicable doctypes and ensuring case-insensitive comparisons, as well as fixing an inconsistency in the custom field options.

### Validation logic improvements:
* [`csf_ke/csf_ke/overrides/validate_pin.py`](diffhunk://#diff-481e319df5761680e488695967624a291b36a7e25b830a1242a0ef9b778688a0R19-R22): Introduced a new variable `doctype_name` for clarity and updated the validation logic to perform a case-insensitive comparison of `is_kra_mandatory` with the applicable doctypes. This ensures more robust and accurate validation.

### Custom field options correction:
* [`csf_ke/fixtures/custom_field.json`](diffhunk://#diff-321b8e7e6c3d9a93b465d414e80b9c6cf70593ddb754387755843334e0c4db5aL98-R98): Fixed a typo in the "options" field by changing "Sales order and Invoice" to "Sales Order and Invoice" for consistency.