### PR TITLE
update: enhance report links and labels in Kenya workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,16 @@ Designed to ensure compliance with Kenyan payroll regulations, these reports gen
   Monthly tax return report submitted by employers to KRA.
 - **NSSF Report**  
   Tracks contributions to the National Social Security Fund (NSSF) for employee social security.
-- **NHIF Report**  
-  Details contributions to the National Hospital Insurance Fund (NHIF) for health insurance.
+- **SHIF Report**  
+  Provides a clear overview of employee Social Health Insurance Fund (SHIF) contributions.
 - **HELB Report**  
   Summarizes deductions for Higher Education Loans Board (HELB) repayments.
 - **Bank Payroll Advice Report**  
   Generates bank-ready instructions for salary disbursements.
 - **Payroll Register Report**  
   Provides a detailed breakdown of payroll transactions for record-keeping and auditing.
+- **Housing Levy Report**  
+  Provides a clear and concise overview of essential employee information alongside their gross salary contributions within a specified period.
 
 ### 2. Tax Reports
 Streamlined reporting for sales and purchase taxes to ensure compliance with Kenyan tax laws.

--- a/csf_ke/csf_ke/workspace/kenya/kenya.json
+++ b/csf_ke/csf_ke/workspace/kenya/kenya.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"id\":\"lFoD5lNDQb\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"Xb7n0Do4eW\",\"type\":\"card\",\"data\":{\"card_name\":\"TIMs HSCodes\",\"col\":4}},{\"id\":\"arLUtR6bvV\",\"type\":\"card\",\"data\":{\"card_name\":\"Pricing Margins\",\"col\":4}},{\"id\":\"fu_Qea0T9L\",\"type\":\"header\",\"data\":{\"text\":\"<span style=\\\"font-size: 18px;\\\"><b>Reports &amp; Masters</b></span>\",\"col\":12}},{\"id\":\"ez66GJZq3i\",\"type\":\"card\",\"data\":{\"card_name\":\"Accounting Reports\",\"col\":4}},{\"id\":\"7bKksk7AZV\",\"type\":\"card\",\"data\":{\"card_name\":\"Payroll Reports\",\"col\":4}}]",
+ "content": "[{\"id\":\"lFoD5lNDQb\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"Xb7n0Do4eW\",\"type\":\"card\",\"data\":{\"card_name\":\"TIMs HSCodes\",\"col\":4}},{\"id\":\"arLUtR6bvV\",\"type\":\"card\",\"data\":{\"card_name\":\"Pricing Margins\",\"col\":4}},{\"id\":\"fu_Qea0T9L\",\"type\":\"header\",\"data\":{\"text\":\"<span style=\\\"font-size: 18px;\\\"><b>Reports &amp; Masters</b></span>\",\"col\":12}},{\"id\":\"ez66GJZq3i\",\"type\":\"card\",\"data\":{\"card_name\":\"Accounting Reports\",\"col\":4}},{\"id\":\"JdLAESQzix\",\"type\":\"card\",\"data\":{\"card_name\":\"Statutory Reports\",\"col\":4}},{\"id\":\"7bKksk7AZV\",\"type\":\"card\",\"data\":{\"card_name\":\"Payroll Reports\",\"col\":4}}]",
  "creation": "2022-11-03 16:41:03.405594",
  "custom_blocks": [],
  "docstatus": 0,
@@ -124,21 +124,11 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Payroll Reports",
-   "link_count": 11,
+   "label": "Statutory Reports",
+   "link_count": 6,
    "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "NHIF Report",
-   "link_count": 0,
-   "link_to": "Kenya NHIF Report",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
   },
   {
    "hidden": 0,
@@ -153,12 +143,61 @@
   {
    "hidden": 0,
    "is_query_report": 1,
+   "label": "SHIF Report",
+   "link_count": 0,
+   "link_to": "Kenya SHIF Contribution",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
    "label": "HELB Report",
    "link_count": 0,
    "link_to": "Kenya HELB Report",
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "P10A Tax Report",
+   "link_count": 0,
+   "link_to": "Kenya P10 Tax Report",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "P9A Tax Reduction Report",
+   "link_count": 0,
+   "link_to": "Kenya P9A Tax Deduction Card Report",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Housing Levy Report",
+   "link_count": 0,
+   "link_to": "Kenya Housing Levy Contribution",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Payroll Reports",
+   "link_count": 4,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
   },
   {
    "hidden": 0,
@@ -183,26 +222,6 @@
   {
    "hidden": 0,
    "is_query_report": 1,
-   "label": "P9A Tax Deduction Card Report",
-   "link_count": 0,
-   "link_to": "Kenya P9A Tax Deduction Card Report",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "P10A Tax Report",
-   "link_count": 0,
-   "link_to": "Kenya P10 Tax Report",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
    "label": "Employee Salary Register",
    "link_count": 0,
    "link_to": "Employee Salary Register With Monthly Comparison",
@@ -219,29 +238,9 @@
    "link_type": "Report",
    "onboard": 0,
    "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "Housing Levy Report",
-   "link_count": 0,
-   "link_to": "Kenya Housing Levy Contribution",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 1,
-   "label": "SHIF Contribution",
-   "link_count": 0,
-   "link_to": "Kenya SHIF Contribution",
-   "link_type": "Report",
-   "onboard": 0,
-   "type": "Link"
   }
  ],
- "modified": "2025-07-02 14:47:56.769544",
+ "modified": "2025-07-02 23:32:35.907809",
  "modified_by": "Administrator",
  "module": "CSF KE",
  "name": "Kenya",


### PR DESCRIPTION
This PR:
- Updates the 'content' section to include additional report cards for 'Statutory Reports' and 'Payroll Reports'.
- Moves the links for the ssf, shif, helb, p10/9, housing levy reports to the Statutory Report from the Payroll report section.
- Removes link to NHIF Report as it is replaced with the new SHIF report.

## Before
![Screenshot from 2025-07-02 23-33-32](https://github.com/user-attachments/assets/c5e41354-37e0-4b41-b39f-44c5e1bcc1a5)

## After
![Screenshot from 2025-07-02 23-33-57](https://github.com/user-attachments/assets/d882e624-277a-406c-baa5-12b50bd187ac)

