### PR TITLE
Feat/custom report print pdf

### DIFF
--- a/csf_ke/csf_ke/report/kenya_p9a_tax_deduction_card_report/custom_kenya_p9a_tax_deduction_card_print_report.py
+++ b/csf_ke/csf_ke/report/kenya_p9a_tax_deduction_card_report/custom_kenya_p9a_tax_deduction_card_print_report.py
@@ -10,6 +10,11 @@ def print_report(report_name, filters=None):
 
         report = frappe.get_doc("Report", report_name)
         columns, data = report.get_data(filters=filters, as_dict=True)
+        data.remove(data[-1])
+
+        totals = calculate_totals(data)
+
+        data.append(totals)
 
         html = frappe.render_template(
             "csf_ke/report/kenya_p9a_tax_deduction_card_report/kenya_p9a_tax_deduction_card_report.html",
@@ -40,3 +45,19 @@ def print_report(report_name, filters=None):
 
     except Exception as e:
         frappe.throw(f"Error generating PDF: {str(e)}")
+
+def calculate_totals(data):
+    if not data:
+        return {}
+
+    totals = {}
+    totals["month"] = "Total"
+
+    fields = [key for key in data[0].keys() if key != "month"]
+
+    for key in fields:
+        totals[key] = sum(
+            float(row.get(key) or 0) for row in data if isinstance(row.get(key), (int, float, str))
+        )
+
+    return totals

--- a/csf_ke/csf_ke/report/kenya_p9a_tax_deduction_card_report/custom_kenya_p9a_tax_deduction_card_print_report.py
+++ b/csf_ke/csf_ke/report/kenya_p9a_tax_deduction_card_report/custom_kenya_p9a_tax_deduction_card_print_report.py
@@ -1,0 +1,42 @@
+import frappe
+from frappe.utils.pdf import get_pdf
+import json
+
+
+@frappe.whitelist()
+def print_report(report_name, filters=None):
+    try:
+        filters = json.loads(filters or "{}")
+
+        report = frappe.get_doc("Report", report_name)
+        columns, data = report.get_data(filters=filters, as_dict=True)
+
+        html = frappe.render_template(
+            "csf_ke/report/kenya_p9a_tax_deduction_card_report/kenya_p9a_tax_deduction_card_report.html",
+            {
+                "title": report.report_name,
+                "filters": filters,
+                "columns": columns,
+                "data": data,
+            },
+        )
+
+        pdf = get_pdf(
+            html,
+            options={
+                "page-size": "A3",
+                "orientation": "Landscape",
+                "margin-top": "10mm",
+                "margin-bottom": "10mm",
+                "margin-left": "10mm",
+                "margin-right": "10mm",
+            },
+        )
+
+        frappe.local.response.filename = f"{report_name}.pdf"
+        frappe.local.response.filecontent = pdf
+        frappe.local.response.type = "pdf"
+        frappe.local.response.mime_type = "application/pdf"
+
+    except Exception as e:
+        frappe.throw(f"Error generating PDF: {str(e)}")

--- a/csf_ke/csf_ke/report/kenya_p9a_tax_deduction_card_report/kenya_p9a_tax_deduction_card_report.html
+++ b/csf_ke/csf_ke/report/kenya_p9a_tax_deduction_card_report/kenya_p9a_tax_deduction_card_report.html
@@ -1,47 +1,118 @@
-{%
-	var report_columns = report.get_columns_for_print();
-%}
-<h2 class="text-left">{%= __(report.report_name) %} {{ __("Year") }} {%= filters.fiscal_year %}</h2>
-<hr>
-<table class="table table-bordered">
-<tr>
-    <td class="text-left">{{ __("Employer's Name:") }} {%= filters.company %}</td>    
-    <td class="text-left">{{ __("Employer's PIN:") }} {%= filters.company_tax_id %}</td>
-</tr>
-<tr>
-    <td class="text-left">{{ __("Employee's Name:") }} {%= filters.employee_name %}</td>
-    <td class="text-left">{{ __("Employee's PIN:") }} {%= filters.employee_tax_id %}</td>
-</tr>
+<style>
+  @page {
+    size: A3 landscape;
+    margin: 10mm;
+  }
+
+  body {
+    font-family: "Helvetica", sans-serif;
+    font-size: 9pt;
+    color: #333;
+  }
+
+  h2 {
+    font-size: 14pt;
+    text-align: left;
+    margin-bottom: 5px;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 8pt;
+    table-layout: auto;
+  }
+
+  th,
+  td {
+    border: 1px solid #ccc;
+    padding: 4px;
+    word-wrap: break-word;
+    white-space: nowrap;
+    text-align: right;
+  }
+
+  th {
+    max-width: 80px;
+    padding: 2px;
+    text-align: center;
+    vertical-align: bottom;
+  }
+  .meta-table td {
+    border: none;
+    text-align: left;
+    font-size: 9pt;
+  }
+
+  .footer {
+    margin-top: 12px;
+    text-align: right;
+    font-size: 8pt;
+    color: #888;
+  }
+</style>
+
+<h2>{{ title }} {{ _("Year") }} {{ filters.fiscal_year }}</h2>
+<hr />
+
+<table class="meta-table">
+  <tr>
+    <td>
+      <strong>{{ _("Employer's Name:") }}</strong> {{ filters.get("company", "")
+      }}
+    </td>
+    <td>
+      <strong>{{ _("Employer's PIN:") }}</strong> {{
+      filters.get("company_tax_id", "") }}
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <strong>{{ _("Employee's Name:") }}</strong> {{
+      filters.get("employee_name", "") }}
+    </td>
+    <td>
+      <strong>{{ _("Employee's PIN:") }}</strong> {{
+      filters.get("employee_tax_id", "") }}
+    </td>
+  </tr>
 </table>
-<hr>
-<table class="table table-bordered">
-	<thead>
-		<tr>
-			{% for(var i=0, l=report_columns.length; i<l; i++) { %}
-				<th class="text-right">{%= report_columns[i].label %}</th>
-			{% } %}
-		</tr>
-	</thead>
-	<tbody>
-		{% for(var j=0, k=data.length; j<k; j++) { %}
-			{%
-				var row = data[j];
-			%}
-			<tr>
-				{% for(var i=0, l=report_columns.length; i<l; i++) { %}
-					<td class="text-right">
-						{% var fieldname = report_columns[i].fieldname; %}
-						{% if (report_columns[i].fieldtype=='Currency' && !isNaN(row[fieldname])) { %}
-							{%= format_currency(row[fieldname]) %}
-						{% } else { %}
-							{% if (!is_null(row[fieldname])) { %}
-								{%= row[fieldname] %}
-							{% } %}
-						{% } %}
-					</td>
-				{% } %}
-			</tr>
-		{% } %}
-	</tbody>
+
+<hr />
+
+<table>
+  <thead>
+    <tr>
+      {% for col in columns if col.fieldname %}
+      <th>
+        {# Split label by space #} {% set parts = col.label.split(' ') %} {#
+        Detect if last part is like "| E1" or "|A" etc. #} {% if '|' in
+        col.label %} {# Find position of the last pipe symbol #} {% set
+        pipe_index = parts.index('|') %} {% set first_part = parts[:pipe_index]
+        %} {% set last_part = ' '.join(parts[pipe_index:]) %} {{ first_part |
+        join('<br />') | safe }}<br /><strong>{{ last_part }}</strong> {% else
+        %} {{ parts | join('<br />') | safe }} {% endif %}
+      </th>
+      {% endfor %}
+    </tr>
+  </thead>
+
+  <tbody>
+    {% for row in data %}
+    <tr>
+      {% for col in columns if col.fieldname %}
+      <td>
+        {% set value = row.get(col.fieldname) %} {% if col.fieldtype ==
+        "Currency" and value is number %} {{ "{:,.2f}".format(value) }} {% else
+        %} {{ value if value else "" }} {% endif %}
+      </td>
+      {% endfor %}
+    </tr>
+    {% endfor %}
+  </tbody>
 </table>
-<p class="text-right text-muted">{{ __("Printed On") }} {%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}</p>
+
+<div class="footer">
+  {{ _("Printed On") }} {{ frappe.utils.format_datetime(frappe.utils.now(),
+  "MMMM d, yyyy, h:mm a") }}
+</div>

--- a/csf_ke/csf_ke/report/kenya_p9a_tax_deduction_card_report/kenya_p9a_tax_deduction_card_report.js
+++ b/csf_ke/csf_ke/report/kenya_p9a_tax_deduction_card_report/kenya_p9a_tax_deduction_card_report.js
@@ -3,98 +3,113 @@
 /* eslint-disable */
 
 frappe.query_reports["Kenya P9A Tax Deduction Card Report"] = {
-	"filters": [
-		{
-			"fieldname": "company",
-			"label": __("Company"),
-			"fieldtype": "Link",
-			"options": "Company",
-			"default": frappe.defaults.get_user_default("Company"),
-			"width": "100px",
-			"reqd": 1,
-			"on_change": function(query_report) {
-                var company = frappe.query_report.get_filter_value('company');
+  onload(report) {
+    report.page.add_inner_button("Print", function () {
+      const filters = report.get_filter_values();
+      const encodedFilters = encodeURIComponent(JSON.stringify(filters));
+      const reportName = report.report_doc.report_name;
 
-				if(company) {
-                    frappe.db.get_value('Company', company, "tax_id", function(value) {
-                    frappe.query_report.set_filter_value('company_tax_id', value["tax_id"]);
-                    });
-				}
-			}
-		},
-		{
-			"fieldname": "employee",
-			"label": __("Employee"),
-			"fieldtype": "Link",
-			"options": "Employee",
-			"width": "100px",
-            "reqd": 1,
-            "get_query": function() {
-				var company = frappe.query_report.get_filter_value('company');
-				return {
-					"doctype": "Employee",
-					"filters": {
-						"company": company,
-					}
-				}
-			},
-			"on_change": function(query_report) {
-				var employee = query_report.get_values().employee;
-				if (!employee) {
-					return;
-				}
-				frappe.model.with_doc("Employee", employee, function(r) {
-					var emp = frappe.model.get_doc("Employee", employee);
-					frappe.query_report.set_filter_value({
-						employee_name: emp.employee_name,
-						employee_tax_id: emp.tax_id
-					});
-				});
-                var company = frappe.query_report.get_filter_value('company');
+      const url = `/api/method/csf_ke.csf_ke.report.kenya_p9a_tax_deduction_card_report.custom_kenya_p9a_tax_deduction_card_print_report.print_report?report_name=${reportName}&filters=${encodedFilters}`;
 
-				if(company) {
-                    frappe.db.get_value('Company', company, "tax_id", function(value) {
-                    frappe.query_report.set_filter_value('company_tax_id', value["tax_id"]);
-                    });
-				}
-			}
-		},
-		{
-			"fieldname": "fiscal_year",
-			"label": __("Year"),
-			"fieldtype": "Link",
-			"options": "Fiscal Year",
-			"default": frappe.defaults.get_user_default("fiscal_year"),
-			"reqd": 1
-		},
-		{
-			"fieldname": "currency",
-			"fieldtype": "Link",
-			"options": "Currency",
-			"label": __("Currency"),
-			"default": erpnext.get_currency(frappe.defaults.get_default("Company")),
-			"read_only": 1,
-			"width": "50px"
-		},
-        {
-			"fieldname":"company_tax_id",
-			"label": __("Company Tax Id"),
-			"fieldtype": "Data",
-			"hidden": 1
-		},
-        {
-			"fieldname":"employee_name",
-			"label": __("Employee Name"),
-			"fieldtype": "Data",
-			"hidden": 1
-		},
-        {
-			"fieldname":"employee_tax_id",
-			"label": __("Employee Tax Id"),
-			"fieldtype": "Data",
-			"hidden": 1
-		}
+      window.open(url, "_blank");
+    });
+  },
+  filters: [
+    {
+      fieldname: "company",
+      label: __("Company"),
+      fieldtype: "Link",
+      options: "Company",
+      default: frappe.defaults.get_user_default("Company"),
+      width: "100px",
+      reqd: 1,
+      on_change: function (query_report) {
+        var company = frappe.query_report.get_filter_value("company");
 
-	]
+        if (company) {
+          frappe.db.get_value("Company", company, "tax_id", function (value) {
+            frappe.query_report.set_filter_value(
+              "company_tax_id",
+              value["tax_id"]
+            );
+          });
+        }
+      },
+    },
+    {
+      fieldname: "employee",
+      label: __("Employee"),
+      fieldtype: "Link",
+      options: "Employee",
+      width: "100px",
+      reqd: 1,
+      get_query: function () {
+        var company = frappe.query_report.get_filter_value("company");
+        return {
+          doctype: "Employee",
+          filters: {
+            company: company,
+          },
+        };
+      },
+      on_change: function (query_report) {
+        var employee = query_report.get_values().employee;
+        if (!employee) {
+          return;
+        }
+        frappe.model.with_doc("Employee", employee, function (r) {
+          var emp = frappe.model.get_doc("Employee", employee);
+          frappe.query_report.set_filter_value({
+            employee_name: emp.employee_name,
+            employee_tax_id: emp.tax_id,
+          });
+        });
+        var company = frappe.query_report.get_filter_value("company");
+
+        if (company) {
+          frappe.db.get_value("Company", company, "tax_id", function (value) {
+            frappe.query_report.set_filter_value(
+              "company_tax_id",
+              value["tax_id"]
+            );
+          });
+        }
+      },
+    },
+    {
+      fieldname: "fiscal_year",
+      label: __("Year"),
+      fieldtype: "Link",
+      options: "Fiscal Year",
+      default: frappe.defaults.get_user_default("fiscal_year"),
+      reqd: 1,
+    },
+    {
+      fieldname: "currency",
+      fieldtype: "Link",
+      options: "Currency",
+      label: __("Currency"),
+      default: erpnext.get_currency(frappe.defaults.get_default("Company")),
+      read_only: 1,
+      width: "50px",
+    },
+    {
+      fieldname: "company_tax_id",
+      label: __("Company Tax Id"),
+      fieldtype: "Data",
+      hidden: 1,
+    },
+    {
+      fieldname: "employee_name",
+      label: __("Employee Name"),
+      fieldtype: "Data",
+      hidden: 1,
+    },
+    {
+      fieldname: "employee_tax_id",
+      label: __("Employee Tax Id"),
+      fieldtype: "Data",
+      hidden: 1,
+    },
+  ],
 };
-


### PR DESCRIPTION

###  Custom PDF Export for Kenya P9A Tax Deduction Card Report



### **Problem**

The default Frappe Print  in landscape mode caused **column overlap and misalignment** in the PDF output, for this report **Kenya P9A Tax Deduction Card** which contain many columns with lengthy labels. This affected usability and presentation when printing or sharing exported reports.
![Screenshot from 2025-07-03 14-01-08](https://github.com/user-attachments/assets/f9ad9c8b-15b3-4c36-ab8f-0b84f5b7d909)




### **Solution**

Implemented a **custom PDF generation mechanism** that utilizes:

* A dedicated backend PDF rendering method.
* A custom HTML template styled specifically for wide A3 landscape layouts.
* A JavaScript-based trigger to generate and download the PDF with correctly structured data and styling.


![Screenshot from 2025-07-03 14-01-40](https://github.com/user-attachments/assets/708ae036-5e3f-4553-b57b-ca899f7547b4)





### **Workflow**

1. **User Action**:
   On report load, a **“Print”** button appears in the report UI and takes them to new page with the processed report document

2. **Trigger Download**:
   When the user clicks the button:

   * The current report filters are gathered.
   * These filters are encoded and sent along with the report name to a backend endpoint via a GET request:

     ```
     /api/method/.../print_report?report_name=...&filters=...
     ```

3. **Backend Processing** (`print_report` Python function):

   * Parses the filters and report name.
   * Calls the standard `get_data()` to retrieve report content.
   * Renders a custom Jinja-based HTML template with that content.
   * Converts the rendered HTML to PDF using `get_pdf()` with **A3 landscape** settings.
   * Sets the response headers to return the generated PDF file with a proper filename.

4. **Frontend PDF Handling**:

   * The browser automatically opens or downloads the PDF file.
   * The layout is clean, non-overlapping, and well-formatted even with wide content.

## TODO:
Check on Total Row  @emmanuel-mwendwa 


