### PR TITLE
update: revise column labels for clarity in kenya_shif_contribution report

### DIFF
--- a/csf_ke/csf_ke/report/kenya_shif_contribution/kenya_shif_contribution.py
+++ b/csf_ke/csf_ke/report/kenya_shif_contribution/kenya_shif_contribution.py
@@ -15,7 +15,7 @@ def get_columns():
     return [
         {
             "fieldname": "payslip_number",
-            "label": "Payslip",
+            "label": "Payroll Number",
             "fieldtype": "Link",
             "options": "Salary Slip",
             "width": 150,
@@ -40,7 +40,7 @@ def get_columns():
         },
         {
             "fieldname": "national_id",
-            "label": "Identity Number",
+            "label": "ID Number",
             "fieldtype": "Data",
             "width": 150,
         },


### PR DESCRIPTION
Updated the label for 'payslip_number' to 'Payroll Number' and 'national_id' to 'ID Number' in the get_columns function to enhance clarity and consistency in the report's output.

## Screenshot

![image](https://github.com/user-attachments/assets/6b07724d-8607-42eb-ac6f-d00adb6fff89)
