### PR TITLE
 feat: enhance date filtering in Kenya Bank Payroll Advice Report

### DIFF
--- a/csf_ke/csf_ke/report/kenya_bank_payroll_advice_report/kenya_bank_payroll_advice_report.js
+++ b/csf_ke/csf_ke/report/kenya_bank_payroll_advice_report/kenya_bank_payroll_advice_report.js
@@ -22,6 +22,7 @@ frappe.query_reports["Kenya Bank Payroll Advice Report"] = {
       width: "100px",
     },
     {
+      fieldname: "to_date",
       label: __("End Date"),
       fieldtype: "Date",
       default: frappe.datetime.add_months(frappe.datetime.month_end()),

--- a/csf_ke/csf_ke/report/kenya_bank_payroll_advice_report/kenya_bank_payroll_advice_report.py
+++ b/csf_ke/csf_ke/report/kenya_bank_payroll_advice_report/kenya_bank_payroll_advice_report.py
@@ -61,7 +61,7 @@ def get_columns():
 		
 	return columns
 
-def get_data(filters,company_currency):
+def get_data(filters, company_currency):
 	if filters.from_date > filters.to_date:
 		frappe.throw(_("To Date cannot be before From Date. {}").format(filters.to_date))
   
@@ -85,9 +85,9 @@ def get_conditions(query, filters, company_currency, salary_slip_doc):
     
     for filter_key, filter_value in filters.items():
         if filter_key == "from_date":
-            query = query.where(salary_slip_doc.start_date == filter_value)
+            query = query.where(salary_slip_doc.start_date >= filter_value)
         elif filter_key == "to_date":
-            query = query.where(salary_slip_doc.end_date == filter_value)
+            query = query.where(salary_slip_doc.end_date <= filter_value)
         elif filter_key == "company":
             query = query.where(salary_slip_doc.company == filter_value)
         elif filter_key =="bank_name":


### PR DESCRIPTION
This pull request introduces improvements to the Kenya Bank Payroll Advice Report by enhancing the date filtering logic and resolving a related **TypeError**. The changes ensure more flexible and accurate data retrieval for the report.

### Changes
1. **Updated Date Filtering Logic** :
   - Modified the `get_data` and `get_conditions` functions to support range-based date filtering.
   - Changed the logic to use `>=` instead of `==` for `salary_slip_doc.start_date` and `salary_slip_doc.end_date`, allowing data retrieval within a date range rather than exact matches.

2. **Added `to_date` Field to Report Filters** :
   - Added the `to_date` fieldname to the Kenya Bank Payroll Advice Report filters.
   - Fixed a `TypeError: '>' not supported between instances of 'str' and 'NoneType'` by ensuring proper handling of date inputs.