### PR TITLE
feat: Update VAT Withholding fields and logic

### DIFF
--- a/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.json
+++ b/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.json
@@ -51,9 +51,11 @@
    "search_index": 1
   },
   {
+   "description": "Use N/A if withholder pin is not available.",
    "fieldname": "withholder_pin",
    "fieldtype": "Data",
    "label": "Withholder PIN",
+   "placeholder": "N/A",
    "reqd": 1
   },
   {
@@ -208,7 +210,7 @@
    "link_fieldname": "cheque_no"
   }
  ],
- "modified": "2025-03-12 13:18:12.388717",
+ "modified": "2025-09-12 12:13:35.965722",
  "modified_by": "Administrator",
  "module": "CSF KE",
  "name": "VAT Withholding",
@@ -231,6 +233,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py
+++ b/csf_ke/csf_ke/doctype/vat_withholding/vat_withholding.py
@@ -10,8 +10,15 @@ class VATWithholding(Document):
         self.set_missing_values()
 
     def set_missing_values(self):
+        empty_withholder_pin_text = "N/A"
         self.currency = "KES"
         self.company = frappe.defaults.get_user_default("Company")
+
+        if (
+            str(self.withholder_pin).upper() == empty_withholder_pin_text
+            and self.voucher_no
+        ):
+            self.withholder_pin = self.get_invoice_tax_id()
 
         if not self.customer and self.withholder_pin:
             self.customer = frappe.db.get_value(
@@ -115,3 +122,11 @@ class VATWithholding(Document):
             je.submit()
 
         return je.name
+
+    def get_invoice_tax_id(self):
+        tax_id = frappe.db.get_value("Sales Invoice", self.voucher_no, "tax_id")
+
+        if not tax_id:
+            frappe.throw(f"Could not find Tax ID for Sales Invoice {self.voucher_no}")
+
+        return tax_id


### PR DESCRIPTION
This pull request focuses on improving the user experience and data accuracy of the VAT Withholding document within the CSF KE module, specifically concerning the **Withholder PIN** field.

The changes streamline data entry by automating the retrieval of the PIN when it is unavailable and provides clearer guidance to the user.

---

### Key Changes:

* **Automated PIN Retrieval:**
    * New backend logic ensures that if the `Withholder PIN` field is set to **"N/A"** (indicating the PIN is unavailable), the system will automatically attempt to fetch the correct Withholder PIN from the related **Sales Invoice**. This reduces manual effort and potential data entry errors.
    * A new `get_invoice_tax_id` method was introduced to reliably retrieve the Tax ID from the Sales Invoice.

* **User Guidance:**
    * The UI for the `withholder_pin` field has been updated to include a **placeholder** and a **description** instructing users to explicitly enter **"N/A"** when the PIN cannot be obtained.

* **Configuration:**
    * The document's `row_format` has been set to "Dynamic" to improve display flexibility.

These updates ensure more robust handling of missing Withholder PINs and provide a better, more guided experience for users completing the VAT Withholding document.

<img width="1580" height="270" alt="image" src="https://github.com/user-attachments/assets/8ec7240b-1752-46bb-b33e-6ab75b0bd9b9" />
