### PR TITLE
fix: trigger the release workflow on branches with version-*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,11 @@ on:
   push:
     branches:
       - develop
-      - version-15
+      - 'version-*'
   pull_request:
+    branches:
+      - develop
+      - 'version-*'
 
 concurrency:
   group: develop-csf_ke-${{ github.event.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,15 @@ on:
     workflows: ["CI"]
     types:
       - completed
+    branches:
+      - 'version-*'
 
 permissions:
   contents: write
 
 jobs:
   release:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'version-')
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -29,8 +29,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          repository: navariltd/navari_csf_ke
-          ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
           token: ${{ steps.get_app_token.outputs.token }}
 


### PR DESCRIPTION
- Ensure release only runs when CI completes on version branches
- Also ensure it only runs if CI succeeds