### PR TITLE
fix: trigger release workflow only after successful CI on version branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,11 @@ jobs:
           bench --site test_site run-tests --app csf_ke --skip-test-records
         env:
           TYPE: server
+
+      - name: Trigger Release
+        if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/version-')
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: ci-success
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,14 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
-    branches:
-      - 'version-*'
+  repository_dispatch:
+    types: [ci-success]
 
 permissions:
   contents: write
 
 jobs:
   release:
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -29,6 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.client_payload.ref }}
           fetch-depth: 0
           token: ${{ steps.get_app_token.outputs.token }}
 


### PR DESCRIPTION
- Replace workflow_run trigger with repository_dispatch for branch detection
- Add ci-success dispatch event from CI workflow on version-* branches
- Ensure release only runs after tests pass on push events