### PR TITLE
fix: Remove validation of mandatory HSCode before saving Item

### DIFF
--- a/csf_ke/hooks.py
+++ b/csf_ke/hooks.py
@@ -139,7 +139,6 @@ after_migrate = "csf_ke.csf_ke.doctype.tims_hscode.tims_hscode.insert_new_record
 doc_events = {
 	"Purchase Receipt": {"on_submit": "csf_ke.csf_ke.doctype.api.update_item_price_list.update_item_prices"},
 	"Purchase Invoice": {"on_submit": "csf_ke.csf_ke.doctype.api.update_item_price_list.update_item_prices"},
-	"Item": {"before_save": "csf_ke.csf_ke.utils.get_tims_hscode.validate_mandatory_hscode"},
 	"Item Group": {"before_save": "csf_ke.csf_ke.utils.get_tims_hscode.validate_mandatory_hscode"},
 	"Customer": {"before_save": "csf_ke.csf_ke.overrides.customer.validate_customer_kra"},
 	"Sales Order": {


### PR DESCRIPTION
This pull request makes a small change to the `csf_ke/hooks.py` configuration by removing the `before_save` event hook for the `Item` doctype. The validation for mandatory HS Code will no longer be triggered when saving an `Item`.

* Removed the `before_save` hook for the `Item` doctype that called `validate_mandatory_hscode`, so mandatory HS Code validation will not run for `Item` saves.