### PR TITLE
fix: change from using company_abbr as key for template csv file names

### DIFF
--- a/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.py
+++ b/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.py
@@ -131,7 +131,7 @@ class KenyaPurchaseTaxReport:
 			supplier_.tax_id.as_("pin_of_supplier"),
 			purchase_invoice_.supplier_name.as_("name_of_supplier"),
 			purchase_invoice_.etr_invoice_number.as_("etr_invoice_number"),
-			purchase_invoice_.posting_date.as_("invoice_date"),
+			purchase_invoice_.bill_date.as_("invoice_date"),
 			purchase_invoice_.name.as_("invoice_name"),
 			purchase_invoice_.base_grand_total.as_("invoice_total_purchases"),
 			purchase_invoice_.return_against.as_("return_against"),
@@ -332,20 +332,29 @@ def download_custom_csv_format(company, from_date=None, to_date=None):
 
 	csv_files = {}
 
+	timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
 	for template_name in tax_templates:
 		pattern = re.compile(rf"{re.escape(template_name)}[\s\-_]*[\d\%]*", re.IGNORECASE)
 
 		all_tax_templates = frappe.get_all("Item Tax Template", fields=["name"])
 
+		template_found = False
+
 		for template in all_tax_templates:
 			match = pattern.match(template["name"])
 			if match:
+				if template_found:
+					continue
+
+				template_found = True
+
 				# Sanitize the company and template names for the file name
 				company_abbr = frappe.db.get_value("Company", company, "abbr") or ""
 				sanitized_template_name = re.sub(r"[^\w]+", "_", template_name).lower()
 
 				# Generate a valid file name
-				csv_file_name = f"purchase_{sanitized_template_name[:5]}_{company_abbr}_{from_date_str}_to_{to_date_str}.csv".strip(
+				csv_file_name = f"purchase_{sanitized_template_name[:7]}_{company_abbr}_{from_date_str}_to_{to_date_str}_{timestamp}.csv".strip(
 					"_"
 				)
 
@@ -402,6 +411,6 @@ def download_custom_csv_format(company, from_date=None, to_date=None):
 					)
 					file_record.insert()
 
-					csv_files[company_abbr] = file_url
+					csv_files[sanitized_template_name] = file_url
 
 	return csv_files

--- a/csf_ke/csf_ke/report/kenya_sales_tax_report/kenya_sales_tax_report.py
+++ b/csf_ke/csf_ke/report/kenya_sales_tax_report/kenya_sales_tax_report.py
@@ -351,20 +351,29 @@ def download_custom_csv_format(company, from_date=None, to_date=None):
 
 	csv_files = {}
 
+	timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
 	for template_name in tax_templates:
 		pattern = re.compile(rf"{re.escape(template_name)}[\s\-_]*[\d\%]*", re.IGNORECASE)
 
 		all_tax_templates = frappe.get_all("Item Tax Template", fields=["name"])
 
+		template_found = False
+
 		for template in all_tax_templates:
 			match = pattern.match(template["name"])
 			if match:
+				if template_found:
+					continue
+
+				template_found = True
+
 				# Sanitize the company and template names for the file name
 				company_abbr = frappe.db.get_value("Company", company, "abbr") or ""
 				sanitized_template_name = re.sub(r"[^\w]+", "_", template_name).lower()
 
 				# Generate a valid file name
-				csv_file_name = f"sales_{sanitized_template_name[:6]}_{company_abbr}_{from_date_str}_to_{to_date_str}.csv".strip(
+				csv_file_name = f"sales_{sanitized_template_name[:6]}_{company_abbr}_{from_date_str}_to_{to_date_str}_{timestamp}.csv".strip(
 					"_"
 				)
 
@@ -424,6 +433,6 @@ def download_custom_csv_format(company, from_date=None, to_date=None):
 					)
 					file_record.insert()
 
-					csv_files[company_abbr] = file_url
+					csv_files[sanitized_template_name] = file_url
 
 	return csv_files


### PR DESCRIPTION
- Each iteration was overwriting the previous entry since all templates were using the same company abbreviation