### PR TITLE
feat: v16 user permission migration tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.14'
 
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
           check-latest: true
 
       - name: Cache pip
@@ -86,15 +86,15 @@ jobs:
       - name: Setup
         run: |
           pip install frappe-bench
-          bench init --frappe-branch version-15 --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
+          bench init --frappe-branch version-16 --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
           mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
           mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
     
       - name: Get Dependencies
         working-directory: /home/runner/frappe-bench
         run: |
-          bench get-app erpnext --branch version-15
-          bench get-app hrms --branch version-15
+          bench get-app erpnext --branch version-16
+          bench get-app hrms --branch version-16
           bench get-app csf_ke $GITHUB_WORKSPACE
     
       - name: Install

--- a/csf_ke/csf_ke/user_permission_migration_tool/test_user_permission_migration_tool.py
+++ b/csf_ke/csf_ke/user_permission_migration_tool/test_user_permission_migration_tool.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Navari Limited and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestUserPermissionMigrationTool(IntegrationTestCase):
+	"""
+	Integration tests for UserPermissionMigrationTool.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/csf_ke/csf_ke/user_permission_migration_tool/user_permission_migration_tool.js
+++ b/csf_ke/csf_ke/user_permission_migration_tool/user_permission_migration_tool.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2026, Navari Limited and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("User Permission Migration Tool", {
+  refresh(frm) {
+    frm.add_custom_button("Run Migration", () => {
+      frappe.call({
+        method: "run_permission_migration",
+        doc: frm.doc,
+        args: {
+          docname: frm.doc.name,
+        },
+        freeze: true,
+        freeze_message: "Starting migration...",
+      });
+    });
+  },
+});

--- a/csf_ke/csf_ke/user_permission_migration_tool/user_permission_migration_tool.js
+++ b/csf_ke/csf_ke/user_permission_migration_tool/user_permission_migration_tool.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("User Permission Migration Tool", {
   refresh(frm) {
-    frm.add_custom_button("Run Migration", () => {
+    frm.add_custom_button(__("Run Migration"), () => {
       frappe.call({
         method: "run_permission_migration",
         doc: frm.doc,
@@ -11,7 +11,7 @@ frappe.ui.form.on("User Permission Migration Tool", {
           docname: frm.doc.name,
         },
         freeze: true,
-        freeze_message: "Starting migration...",
+        freeze_message: __("Starting migration..."),
       });
     });
   },

--- a/csf_ke/csf_ke/user_permission_migration_tool/user_permission_migration_tool.json
+++ b/csf_ke/csf_ke/user_permission_migration_tool/user_permission_migration_tool.json
@@ -1,0 +1,65 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-03-10 13:50:53.830700",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "user",
+  "status",
+  "column_break_aqgq",
+  "run_for_all_users"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Idle\nRunning\nCompleted\nFailed"
+  },
+  {
+   "fieldname": "column_break_aqgq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "run_for_all_users",
+   "fieldtype": "Check",
+   "label": "Run For All Users"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2026-03-10 13:57:32.573342",
+ "modified_by": "Administrator",
+ "module": "Nl Royaloven",
+ "name": "User Permission Migration Tool",
+ "owner": "mwendwa@navari.co.ke",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/csf_ke/csf_ke/user_permission_migration_tool/user_permission_migration_tool.py
+++ b/csf_ke/csf_ke/user_permission_migration_tool/user_permission_migration_tool.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026, Navari Limited and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+from frappe.permissions import get_valid_perms
+
+logger = frappe.logger("user_permission_migration", allow_site=True, file_count=50)
+
+
+class UserPermissionMigrationTool(Document):
+	@frappe.whitelist()
+	def run_permission_migration(self):
+		self.status = "Running"
+		self.save(ignore_permissions=True)
+
+		frappe.enqueue(
+			"csf_ke.csf_ke.doctype.user_permission_migration_tool.user_permission_migration_tool.permission_migration_job",
+			docname=self.name,
+			queue="long",
+			timeout=15000,
+		)
+
+		return "Job Started"
+
+
+def permission_migration_job(docname):
+	doc = frappe.get_single("User Permission Migration Tool")
+
+	logger.info(f"Starting permission migration for tool {docname}")
+
+	try:
+		if doc.run_for_all_users:
+			users = frappe.get_all(
+				"User",
+				filters={"enabled": 1, "user_type": "System User"},
+				pluck="name",
+			)
+		else:
+			users = [doc.user]
+
+		for user in users:
+			logger.info(f"Processing user: {user}")
+
+			propagate_user_permissions(user)
+
+			logger.info(f"Finished user: {user}")
+
+		doc.status = "Completed"
+		doc.save(ignore_permissions=True)
+
+		logger.info("Migration completed successfully")
+
+	except Exception:
+		doc.status = "Failed"
+		doc.save(ignore_permissions=True)
+
+		logger.error(frappe.get_traceback())
+
+
+def propagate_user_permissions(user):
+	"""
+	Convert global user permissions (apply_to_all_doctypes=1)
+	into scoped permissions using applicable_for.
+
+	Company permissions are ignored and left global.
+	"""
+
+	# get all user permissions
+	permissions = frappe.get_all(
+		"User Permission",
+		filters={"user": user},
+		fields=[
+			"name",
+			"allow",
+			"for_value",
+			"apply_to_all_doctypes",
+		],
+	)
+
+	# get all doctypes user has access to
+	user_doctypes = {
+		p["parent"]
+		for p in get_valid_perms(user=user)
+		if p.get("permlevel") == 0 and (p.get("read") or p.get("write") or p.get("create"))
+	}
+
+	# metadata cache (avoid repeated meta loading)
+	meta_cache = {}
+
+	def get_meta(dt):
+		if dt in meta_cache:
+			return meta_cache[dt]
+
+		if not frappe.db.exists("DocType", dt):
+			meta_cache[dt] = None
+			return None
+
+		try:
+			meta_cache[dt] = frappe.get_meta(dt)
+		except Exception:
+			meta_cache[dt] = None
+
+		return meta_cache[dt]
+
+	for perm in permissions:
+		master = perm["allow"]
+		value = perm["for_value"]
+
+		# ignore company permissions entirely
+		if master == "Company":
+			continue
+
+		# only handle global permissions
+		if not perm["apply_to_all_doctypes"]:
+			continue
+
+		# master meta
+		master_meta = get_meta(master)
+
+		# only propagate masters belonging to a company
+		if not master_meta.has_field("company"):
+			continue
+
+		created = 0
+
+		for dt in user_doctypes:
+			# skip master itself and company
+			if dt in {master, "Company"}:
+				continue
+
+			meta = get_meta(dt)
+
+			if not meta:
+				continue
+
+			# skip child tables and singles
+			if meta.istable or meta.issingle:
+				continue
+
+			# check if doctype links to master
+			has_link = any(df.fieldtype == "Link" and df.options == master for df in meta.fields)
+
+			if not has_link:
+				continue
+
+			# check if permission already exists
+			exists = frappe.db.exists(
+				"User Permission",
+				{
+					"user": user,
+					"allow": master,
+					"for_value": value,
+					"applicable_for": dt,
+				},
+			)
+
+			if exists:
+				continue
+
+			# create scoped permission
+			frappe.get_doc(
+				{
+					"doctype": "User Permission",
+					"user": user,
+					"allow": master,
+					"for_value": value,
+					"apply_to_all_doctypes": 0,
+					"applicable_for": dt,
+				}
+			).insert(ignore_permissions=True)
+
+			logger.info(f"Creating permission: user={user} master={master} value={value} applicable_for={dt}")
+
+			created += 1
+
+		# only delete global permission if we created replacements
+		if created > 0:
+			frappe.delete_doc(
+				"User Permission",
+				perm["name"],
+				ignore_permissions=True,
+			)
+
+			logger.info(f"Deleting global permission {perm['name']} for {master}:{value}")
+
+	frappe.db.commit()

--- a/csf_ke/csf_ke/user_permission_migration_tool/user_permission_migration_tool.py
+++ b/csf_ke/csf_ke/user_permission_migration_tool/user_permission_migration_tool.py
@@ -184,4 +184,4 @@ def propagate_user_permissions(user):
 
 			logger.info(f"Deleting global permission {perm['name']} for {master}:{value}")
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep


### PR DESCRIPTION
This pull request introduces a new "User Permission Migration Tool" feature, including its backend logic and frontend integration. The main goal is to provide a tool for migrating global user permissions to more scoped, doctype-specific permissions, with a user interface and background job processing.

The most important changes are:

**Backend logic and migration job:**

* Added `UserPermissionMigrationTool` DocType and backend logic in `user_permission_migration_tool.py`, including a method to enqueue a background job (`run_permission_migration`) and the migration job itself (`permission_migration_job`). The migration converts global user permissions into scoped permissions for applicable doctypes, skipping company permissions and cleaning up replaced permissions. Logging and error handling are included.
* Introduced the `propagate_user_permissions` function to perform the actual migration per user, ensuring permissions are only scoped where appropriate and avoiding duplicates.

**Frontend integration:**

* Added a client-side script (`user_permission_migration_tool.js`) that adds a "Run Migration" button to the tool's form, triggering the backend migration process via a frappe call.

**DocType definition:**

* Created the `User Permission Migration Tool` DocType definition (`user_permission_migration_tool.json`), including fields for user selection, migration status, and an option to run for all users. Permissions are restricted to System Managers.