### PR TITLE
refactor: update eTIMS doctype permissions and timestamps

### DIFF
--- a/csf_ke/etims/doctype/etims_country_of_origin/etims_country_of_origin.json
+++ b/csf_ke/etims/doctype/etims_country_of_origin/etims_country_of_origin.json
@@ -73,7 +73,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-03 15:12:42.333523",
+ "modified": "2026-06-11 17:46:19.292503",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Country of Origin",
@@ -89,6 +89,46 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
    "share": 1,
    "write": 1
   }

--- a/csf_ke/etims/doctype/etims_import_item_status/etims_import_item_status.json
+++ b/csf_ke/etims/doctype/etims_import_item_status/etims_import_item_status.json
@@ -59,7 +59,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-19 13:56:25.520088",
+ "modified": "2026-06-11 17:42:37.007717",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Import Item Status",
@@ -75,6 +75,50 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
    "share": 1,
    "write": 1
   }

--- a/csf_ke/etims/doctype/etims_item_classification/etims_item_classification.json
+++ b/csf_ke/etims/doctype/etims_item_classification/etims_item_classification.json
@@ -69,7 +69,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-03 15:19:20.231225",
+ "modified": "2026-06-11 17:46:47.621400",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Item Classification",
@@ -85,6 +85,46 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
    "share": 1,
    "write": 1
   }

--- a/csf_ke/etims/doctype/etims_item_type/etims_item_type.json
+++ b/csf_ke/etims/doctype/etims_item_type/etims_item_type.json
@@ -60,7 +60,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-19 13:57:04.418428",
+ "modified": "2026-06-11 17:45:26.896630",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Item Type",
@@ -76,6 +76,46 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
    "share": 1,
    "write": 1
   }

--- a/csf_ke/etims/doctype/etims_notices/etims_notices.json
+++ b/csf_ke/etims/doctype/etims_notices/etims_notices.json
@@ -57,7 +57,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-19 13:57:24.616290",
+ "modified": "2026-06-11 17:44:08.120983",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Notices",
@@ -73,6 +73,50 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
    "share": 1,
    "write": 1
   }

--- a/csf_ke/etims/doctype/etims_packaging_unit/etims_packaging_unit.json
+++ b/csf_ke/etims/doctype/etims_packaging_unit/etims_packaging_unit.json
@@ -73,7 +73,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-03 16:02:06.708761",
+ "modified": "2026-06-11 17:47:37.785744",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Packaging Unit",
@@ -89,6 +89,46 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
    "share": 1,
    "write": 1
   }

--- a/csf_ke/etims/doctype/etims_product_type/etims_product_type.json
+++ b/csf_ke/etims/doctype/etims_product_type/etims_product_type.json
@@ -59,7 +59,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-19 13:58:41.297375",
+ "modified": "2026-06-11 17:45:17.125573",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Product Type",
@@ -75,6 +75,46 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
    "share": 1,
    "write": 1
   }

--- a/csf_ke/etims/doctype/etims_queue_manager/etims_queue_manager.json
+++ b/csf_ke/etims/doctype/etims_queue_manager/etims_queue_manager.json
@@ -63,7 +63,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-02 16:38:12.613896",
+ "modified": "2026-06-11 17:41:04.255279",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Queue Manager",
@@ -76,6 +76,42 @@
    "print": 1,
    "read": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Sales User",
    "share": 1,
    "write": 1
   }

--- a/csf_ke/etims/doctype/etims_registered_imported_item/etims_registered_imported_item.json
+++ b/csf_ke/etims/doctype/etims_registered_imported_item/etims_registered_imported_item.json
@@ -1,228 +1,272 @@
 {
-  "actions": [],
-  "allow_import": 1,
-  "allow_rename": 1,
-  "autoname": "hash",
-  "creation": "2026-03-22 12:43:06.821039",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": [
-    "item_name",
-    "product_name",
-    "product_code",
-    "origin_nation_code",
-    "declaration_date",
-    "item_sequence",
-    "package",
-    "suppliers_name",
-    "invoice_foreign_currency_amount",
-    "purchase_invoice",
-    "column_break_cbnh",
-    "task_code",
-    "export_nation_code",
-    "declaration_number",
-    "hs_code",
-    "etims_packaging_unit_code",
-    "quantity_unit_code",
-    "agent_name",
-    "invoice_foreign_currency",
-    "invoice_foreign_currency_rate",
-    "column_break_dkbf",
-    "branch",
-    "imported_item_status",
-    "imported_item_status_code",
-    "quantity",
-    "net_weight",
-    "gross_weight",
-    "is_mapped",
-    "sent_to_etims"
-  ],
-  "fields": [
-    {
-      "fieldname": "item_name",
-      "fieldtype": "Data",
-      "label": "Item Name"
-    },
-    {
-      "fieldname": "product_name",
-      "fieldtype": "Data",
-      "label": "Product Name"
-    },
-    {
-      "fieldname": "product_code",
-      "fieldtype": "Data",
-      "label": "Product Code"
-    },
-    {
-      "fieldname": "origin_nation_code",
-      "fieldtype": "Link",
-      "label": "Origin Nation Code",
-      "options": "eTims Country of Origin"
-    },
-    {
-      "fieldname": "declaration_date",
-      "fieldtype": "Date",
-      "label": "Declaration Date"
-    },
-    {
-      "fieldname": "item_sequence",
-      "fieldtype": "Int",
-      "label": "Item Sequence"
-    },
-    {
-      "fieldname": "package",
-      "fieldtype": "Data",
-      "label": "Package"
-    },
-    {
-      "fieldname": "suppliers_name",
-      "fieldtype": "Data",
-      "label": "Supplier's Name"
-    },
-    {
-      "fieldname": "invoice_foreign_currency_amount",
-      "fieldtype": "Data",
-      "label": "Invoice Foreign Currency Amount"
-    },
-    {
-      "fieldname": "purchase_invoice",
-      "fieldtype": "Data",
-      "hidden": 1,
-      "label": "Purchase Invoice"
-    },
-    {
-      "fieldname": "column_break_cbnh",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "task_code",
-      "fieldtype": "Data",
-      "label": "Task Code"
-    },
-    {
-      "fieldname": "export_nation_code",
-      "fieldtype": "Link",
-      "label": "Export Nation Code",
-      "options": "eTims Country of Origin"
-    },
-    {
-      "fieldname": "declaration_number",
-      "fieldtype": "Data",
-      "label": "Declaration Number"
-    },
-    {
-      "fieldname": "hs_code",
-      "fieldtype": "Data",
-      "label": "HS Code"
-    },
-    {
-      "fieldname": "etims_packaging_unit_code",
-      "fieldtype": "Link",
-      "label": "Packaging Unit Code",
-      "options": "eTims Packaging Unit"
-    },
-    {
-      "fieldname": "quantity_unit_code",
-      "fieldtype": "Link",
-      "label": "Quantity Unit Code",
-      "options": "eTims Unit of Quantity"
-    },
-    {
-      "fieldname": "agent_name",
-      "fieldtype": "Data",
-      "label": "Agent Name"
-    },
-    {
-      "fieldname": "invoice_foreign_currency",
-      "fieldtype": "Data",
-      "label": "Invoice Foreign Currency"
-    },
-    {
-      "fieldname": "invoice_foreign_currency_rate",
-      "fieldtype": "Data",
-      "label": "Invoice Foreign Currency Rate"
-    },
-    {
-      "fieldname": "column_break_dkbf",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "branch",
-      "fieldtype": "Link",
-      "label": "Branch",
-      "options": "Branch"
-    },
-    {
-      "fieldname": "imported_item_status",
-      "fieldtype": "Link",
-      "label": "imported Item Status",
-      "options": "eTims Import Item Status"
-    },
-    {
-      "fieldname": "imported_item_status_code",
-      "fieldtype": "Data",
-      "label": "imported Item Status Code"
-    },
-    {
-      "fieldname": "quantity",
-      "fieldtype": "Int",
-      "label": "Quantity"
-    },
-    {
-      "fieldname": "net_weight",
-      "fieldtype": "Float",
-      "label": "Net Weight"
-    },
-    {
-      "fieldname": "gross_weight",
-      "fieldtype": "Float",
-      "label": "Gross Weight",
-      "precision": "2"
-    },
-    {
-      "default": "0",
-      "fieldname": "is_mapped",
-      "fieldtype": "Check",
-      "label": "Is Mapped",
-      "read_only": 1
-    },
-    {
-      "default": "0",
-      "fieldname": "sent_to_etims",
-      "fieldtype": "Check",
-      "label": "Sent to eTims",
-      "read_only": 1
-    }
-  ],
-  "in_create": 1,
-  "index_web_pages_for_search": 1,
-  "links": [],
-  "modified": "2026-05-19 13:57:51.714186",
-  "modified_by": "Administrator",
-  "module": "eTims",
-  "name": "eTims Registered Imported Item",
-  "naming_rule": "Random",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "row_format": "Dynamic",
-  "search_fields": "item_name, task_code",
-  "show_title_field_in_link": 1,
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [],
-  "title_field": "item_name",
-  "track_changes": 1
+ "actions": [],
+ "allow_import": 1,
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2026-03-22 12:43:06.821039",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "item_name",
+  "product_name",
+  "product_code",
+  "origin_nation_code",
+  "declaration_date",
+  "item_sequence",
+  "package",
+  "suppliers_name",
+  "invoice_foreign_currency_amount",
+  "purchase_invoice",
+  "column_break_cbnh",
+  "task_code",
+  "export_nation_code",
+  "declaration_number",
+  "hs_code",
+  "etims_packaging_unit_code",
+  "quantity_unit_code",
+  "agent_name",
+  "invoice_foreign_currency",
+  "invoice_foreign_currency_rate",
+  "column_break_dkbf",
+  "branch",
+  "imported_item_status",
+  "imported_item_status_code",
+  "quantity",
+  "net_weight",
+  "gross_weight",
+  "is_mapped",
+  "sent_to_etims"
+ ],
+ "fields": [
+  {
+   "fieldname": "item_name",
+   "fieldtype": "Data",
+   "label": "Item Name"
+  },
+  {
+   "fieldname": "product_name",
+   "fieldtype": "Data",
+   "label": "Product Name"
+  },
+  {
+   "fieldname": "product_code",
+   "fieldtype": "Data",
+   "label": "Product Code"
+  },
+  {
+   "fieldname": "origin_nation_code",
+   "fieldtype": "Link",
+   "label": "Origin Nation Code",
+   "options": "eTims Country of Origin"
+  },
+  {
+   "fieldname": "declaration_date",
+   "fieldtype": "Date",
+   "label": "Declaration Date"
+  },
+  {
+   "fieldname": "item_sequence",
+   "fieldtype": "Int",
+   "label": "Item Sequence"
+  },
+  {
+   "fieldname": "package",
+   "fieldtype": "Data",
+   "label": "Package"
+  },
+  {
+   "fieldname": "suppliers_name",
+   "fieldtype": "Data",
+   "label": "Supplier's Name"
+  },
+  {
+   "fieldname": "invoice_foreign_currency_amount",
+   "fieldtype": "Data",
+   "label": "Invoice Foreign Currency Amount"
+  },
+  {
+   "fieldname": "purchase_invoice",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Purchase Invoice"
+  },
+  {
+   "fieldname": "column_break_cbnh",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "task_code",
+   "fieldtype": "Data",
+   "label": "Task Code"
+  },
+  {
+   "fieldname": "export_nation_code",
+   "fieldtype": "Link",
+   "label": "Export Nation Code",
+   "options": "eTims Country of Origin"
+  },
+  {
+   "fieldname": "declaration_number",
+   "fieldtype": "Data",
+   "label": "Declaration Number"
+  },
+  {
+   "fieldname": "hs_code",
+   "fieldtype": "Data",
+   "label": "HS Code"
+  },
+  {
+   "fieldname": "etims_packaging_unit_code",
+   "fieldtype": "Link",
+   "label": "Packaging Unit Code",
+   "options": "eTims Packaging Unit"
+  },
+  {
+   "fieldname": "quantity_unit_code",
+   "fieldtype": "Link",
+   "label": "Quantity Unit Code",
+   "options": "eTims Unit of Quantity"
+  },
+  {
+   "fieldname": "agent_name",
+   "fieldtype": "Data",
+   "label": "Agent Name"
+  },
+  {
+   "fieldname": "invoice_foreign_currency",
+   "fieldtype": "Data",
+   "label": "Invoice Foreign Currency"
+  },
+  {
+   "fieldname": "invoice_foreign_currency_rate",
+   "fieldtype": "Data",
+   "label": "Invoice Foreign Currency Rate"
+  },
+  {
+   "fieldname": "column_break_dkbf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "branch",
+   "fieldtype": "Link",
+   "label": "Branch",
+   "options": "Branch"
+  },
+  {
+   "fieldname": "imported_item_status",
+   "fieldtype": "Link",
+   "label": "imported Item Status",
+   "options": "eTims Import Item Status"
+  },
+  {
+   "fieldname": "imported_item_status_code",
+   "fieldtype": "Data",
+   "label": "imported Item Status Code"
+  },
+  {
+   "fieldname": "quantity",
+   "fieldtype": "Int",
+   "label": "Quantity"
+  },
+  {
+   "fieldname": "net_weight",
+   "fieldtype": "Float",
+   "label": "Net Weight"
+  },
+  {
+   "fieldname": "gross_weight",
+   "fieldtype": "Float",
+   "label": "Gross Weight",
+   "precision": "2"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_mapped",
+   "fieldtype": "Check",
+   "label": "Is Mapped",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "sent_to_etims",
+   "fieldtype": "Check",
+   "label": "Sent to eTims",
+   "read_only": 1
+  }
+ ],
+ "in_create": 1,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-06-11 17:44:33.630819",
+ "modified_by": "Administrator",
+ "module": "eTims",
+ "name": "eTims Registered Imported Item",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "search_fields": "item_name, task_code",
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "item_name",
+ "track_changes": 1
 }

--- a/csf_ke/etims/doctype/etims_routes/etims_routes.json
+++ b/csf_ke/etims/doctype/etims_routes/etims_routes.json
@@ -1,67 +1,76 @@
 {
-  "actions": [],
-  "allow_rename": 1,
-  "autoname": "format:{vendor}",
-  "creation": "2026-03-22 09:28:28.678440",
-  "default_view": "List",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": [
-    "vendor_settings_section",
-    "vendor",
-    "routes_mapping_section",
-    "routes_table"
-  ],
-  "fields": [
-    {
-      "fieldname": "vendor_settings_section",
-      "fieldtype": "Section Break",
-      "label": "Vendor Settings"
-    },
-    {
-      "default": "OSCU KRA",
-      "fieldname": "vendor",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "label": "API Provider",
-      "reqd": 1
-    },
-    {
-      "fieldname": "routes_mapping_section",
-      "fieldtype": "Section Break",
-      "label": "Routes Mapping"
-    },
-    {
-      "fieldname": "routes_table",
-      "fieldtype": "Table",
-      "label": "Routes Table",
-      "options": "eTims Route Table Item"
-    }
-  ],
-  "index_web_pages_for_search": 1,
-  "links": [],
-  "modified": "2026-05-19 13:55:52.447859",
-  "modified_by": "Administrator",
-  "module": "eTims",
-  "name": "eTims Routes",
-  "naming_rule": "Expression (old style)",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "print": 1,
-      "read": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "row_format": "Dynamic",
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [],
-  "track_changes": 1,
-  "track_views": 1
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:{vendor}",
+ "creation": "2026-03-22 09:28:28.678440",
+ "default_view": "List",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "vendor_settings_section",
+  "vendor",
+  "routes_mapping_section",
+  "routes_table"
+ ],
+ "fields": [
+  {
+   "fieldname": "vendor_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Vendor Settings"
+  },
+  {
+   "default": "OSCU KRA",
+   "fieldname": "vendor",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "API Provider",
+   "reqd": 1
+  },
+  {
+   "fieldname": "routes_mapping_section",
+   "fieldtype": "Section Break",
+   "label": "Routes Mapping"
+  },
+  {
+   "fieldname": "routes_table",
+   "fieldtype": "Table",
+   "label": "Routes Table",
+   "options": "eTims Route Table Item"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-06-11 17:41:55.824216",
+ "modified_by": "Administrator",
+ "module": "eTims",
+ "name": "eTims Routes",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "All",
+   "share": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1,
+ "track_views": 1
 }

--- a/csf_ke/etims/doctype/etims_taxation_type/etims_taxation_type.json
+++ b/csf_ke/etims/doctype/etims_taxation_type/etims_taxation_type.json
@@ -114,7 +114,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-03 16:14:47.024436",
+ "modified": "2026-06-11 17:48:51.152588",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Taxation Type",
@@ -130,6 +130,46 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
    "share": 1,
    "write": 1
   }

--- a/csf_ke/etims/doctype/etims_unit_of_quantity/etims_unit_of_quantity.json
+++ b/csf_ke/etims/doctype/etims_unit_of_quantity/etims_unit_of_quantity.json
@@ -68,7 +68,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-03 16:02:50.681845",
+ "modified": "2026-06-11 17:48:11.630585",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Unit of Quantity",
@@ -84,6 +84,46 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
    "share": 1,
    "write": 1
   }


### PR DESCRIPTION
Update 'modified' timestamps for multiple 'eTIMS' doctypes and  add new 'Permission Entries' for 'Accounts Manager', 'Accounts  User', 'Sales Manager', and 'Sales User' roles to refine 'Access  Control' across 'etims_country_of_origin', 'etims_import_item_status',  'etims_item_classification', 'etims_item_type', 'etims_notices',  'etims_packaging_unit', 'etims_product_type', 'etims_queue_manager',  'etims_registered_imported_item', 'etims_routes', 'etims_taxation_type',  and 'etims_unit_of_quantity'.

- Update modified timestamps for all listed eTIMS doctypes.
- Add role-based permissions for Accounts and Sales roles.
- Add 'All' role permission to etims_routes doctype.
- Refine access control across eTIMS configuration doctypes.