### PR TITLE
feat: enhance Sales Ledger Entry filters and auto-populate company field

### DIFF
--- a/csf_ke/etims/doctype/etims_sales_ledger_entry/etims_sales_ledger_entry.json
+++ b/csf_ke/etims/doctype/etims_sales_ledger_entry/etims_sales_ledger_entry.json
@@ -337,8 +337,13 @@
  "grid_page_length": 50,
  "in_create": 1,
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2026-06-13 13:42:24.279008",
+ "links": [
+  {
+   "link_doctype": "eTIMS Sales Ledger Entry",
+   "link_fieldname": "etims_invoice"
+  }
+ ],
+ "modified": "2026-06-18 02:23:26.155691",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTIMS Sales Ledger Entry",

--- a/csf_ke/etims/doctype/etims_sales_ledger_entry/etims_sales_ledger_entry.json
+++ b/csf_ke/etims/doctype/etims_sales_ledger_entry/etims_sales_ledger_entry.json
@@ -137,6 +137,7 @@
    "fieldtype": "Link",
    "in_filter": 1,
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Sales Invoice",
    "options": "Sales Invoice",
    "read_only": 1,
@@ -147,6 +148,7 @@
    "fieldtype": "Link",
    "in_filter": 1,
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "eTims Invoice",
    "options": "eTIMS Sales Ledger Entry",
    "read_only": 1
@@ -175,7 +177,9 @@
   {
    "fieldname": "customer_name",
    "fieldtype": "Data",
+   "in_filter": 1,
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Customer Name",
    "read_only": 1
   },
@@ -237,6 +241,7 @@
   {
    "fieldname": "scu_invoice_number",
    "fieldtype": "Data",
+   "in_filter": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "SCU Invoice Number",
@@ -321,6 +326,9 @@
   {
    "fieldname": "etims_id",
    "fieldtype": "Data",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "eTims ID",
    "read_only": 1,
    "unique": 1

--- a/csf_ke/etims/doctype/etims_sales_ledger_entry/etims_sales_ledger_entry.py
+++ b/csf_ke/etims/doctype/etims_sales_ledger_entry/etims_sales_ledger_entry.py
@@ -27,3 +27,7 @@ class eTIMSSalesLedgerEntry(Document):
 			)
 			if sales_invoice:
 				self.sales_invoice = sales_invoice
+
+		if self.sales_invoice:
+			company = frappe.db.get_value("Sales Invoice", self.sales_invoice, "company")
+			self.company = company


### PR DESCRIPTION
This pull request enhances the usability and filtering capabilities of the `eTIMS Sales Ledger Entry` DocType by improving its filter options and establishing better document linking. The changes make it easier for users to filter and search for records, and ensure that the `company` field is automatically populated based on the selected sales invoice.

Improvements to filtering and search:

* Added `in_standard_filter` and/or `in_filter` to key fields (`sales_invoice`, `etims_invoice`, `customer_name`, `scu_invoice_number`, `etims_id`) in `etims_sales_ledger_entry.json` to enable advanced filtering and make these fields more accessible in list and filter views. [[1]](diffhunk://#diff-73321f19457437962eba9172b3d94ac2033164c23f7c984a1681c27c9449668cR140) [[2]](diffhunk://#diff-73321f19457437962eba9172b3d94ac2033164c23f7c984a1681c27c9449668cR151) [[3]](diffhunk://#diff-73321f19457437962eba9172b3d94ac2033164c23f7c984a1681c27c9449668cR180-R182) [[4]](diffhunk://#diff-73321f19457437962eba9172b3d94ac2033164c23f7c984a1681c27c9449668cR244) [[5]](diffhunk://#diff-73321f19457437962eba9172b3d94ac2033164c23f7c984a1681c27c9449668cR329-R331)

Enhancements to document linking:

* Added a link from `eTIMS Sales Ledger Entry` to itself via the `etims_invoice` field in the `links` section, improving navigation between related documents.

Automation and data consistency:

* Updated the `link_related_document` method in `etims_sales_ledger_entry.py` to automatically set the `company` field based on the selected `sales_invoice`, ensuring data consistency.