### PR TITLE
chore: adjust eTIMS job queue page size and route table grid length

### DIFF
--- a/csf_ke/etims/doctype/etims_job_queue/etims_job_queue.json
+++ b/csf_ke/etims/doctype/etims_job_queue/etims_job_queue.json
@@ -178,7 +178,7 @@
    "read_only": 1
   },
   {
-   "default": "1000",
+   "default": "200",
    "fieldname": "page_size",
    "fieldtype": "Int",
    "label": "Page Size",
@@ -241,7 +241,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-09 15:46:08.427078",
+ "modified": "2026-06-20 05:25:01.041220",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Job Queue",

--- a/csf_ke/etims/doctype/etims_route_table_item/etims_route_table_item.json
+++ b/csf_ke/etims/doctype/etims_route_table_item/etims_route_table_item.json
@@ -52,10 +52,11 @@
    "label": "Last Request Date"
   }
  ],
+ "grid_page_length": 100,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-19 13:59:04.797356",
+ "modified": "2026-06-20 05:25:21.031398",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Route Table Item",


### PR DESCRIPTION
Update the 'Default Page Size' for the 'eTIMS Job Queue' to  improve 'Performance' and 'Consistency', and configure a 'Grid  Page Length' for the 'eTIMS Route Table Item' to improve 'User  Experience' when viewing large 'Datasets', while updating  'modified' timestamps to reflect the latest 'Configuration  Changes'.

- Adjust job queue default page size for better performance.
- Set route table item grid page length for large datasets.
- Update modified timestamps for configuration changes.
- Improve user experience in route table views.