### PR TITLE
perf: adjust eTIMS job queue page size and route table grid length

### DIFF
--- a/csf_ke/etims/doctype/etims_job_queue/etims_job_queue.json
+++ b/csf_ke/etims/doctype/etims_job_queue/etims_job_queue.json
@@ -178,7 +178,7 @@
    "read_only": 1
   },
   {
-   "default": "1000",
+   "default": "200",
    "fieldname": "page_size",
    "fieldtype": "Int",
    "label": "Page Size",
@@ -241,7 +241,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-09 15:46:08.427078",
+ "modified": "2026-06-20 05:25:01.041220",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Job Queue",

--- a/csf_ke/etims/doctype/etims_route_table_item/etims_route_table_item.json
+++ b/csf_ke/etims/doctype/etims_route_table_item/etims_route_table_item.json
@@ -52,10 +52,11 @@
    "label": "Last Request Date"
   }
  ],
+ "grid_page_length": 100,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-19 13:59:04.797356",
+ "modified": "2026-06-20 05:25:21.031398",
  "modified_by": "Administrator",
  "module": "eTims",
  "name": "eTims Route Table Item",


### PR DESCRIPTION
This pull request makes configuration updates to the eTims module's DocTypes to adjust default pagination and grid display settings. The main changes involve reducing the default page size for job queues and setting the grid page length for route table items.

**Pagination and grid display updates:**

* Reduced the default value of the `page_size` field from 1000 to 200 in the `etims_job_queue` DocType, likely to improve performance or user experience when displaying large datasets.
* Set `grid_page_length` to 100 in the `etims_route_table_item` DocType, specifying how many rows are shown per page in the grid view.

**Administrative/metadata updates:**

* Updated the `modified` timestamps in both DocType JSON files to reflect the latest changes. [[1]](diffhunk://#diff-a48e1fbcf4b45ecc4e8aae314969876d0bfb0b97b1e93133c90f6891312d979aL244-R244) [[2]](diffhunk://#diff-a1423a32b4f6c9832b2c0eba3500567aa999d7bd7af65f6fa96ac4116c242939R55-R59)