### PR TITLE
chore: define benchmark dependencies for core modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ dependencies = [
     "qrcode~=7.4.2",
 ]
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0,<16.0.0"
+erpnext = ">=15.0.0,<16.0.0"
+hrms = ">=15.0.0,<16.0.0"
+
 [build-system]
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"


### PR DESCRIPTION
Add a new '[tool.bench.frappe-dependencies]' section to 'pyproject.toml' to explicitly define 'Version Constraints' for core ecosystem packages ('frappe', 'erpnext', and 'hrms'), ensuring that environment setups maintain 'Compatibility' with 'Version 15' of the framework and its associated business applications.

- Add frappe-dependencies section with version 15 constraints.
- Pin erpnext and hrms to compatible version ranges.
- Ensure environment consistency for core module dependencies.