### PR TITLE
chore: add ERPNext and HRMS to bench dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,5 @@ docstring-code-format = true
 
 [tool.bench.frappe-dependencies]
 frappe = ">=16.0.0,<17.0.0"
+erpnext = ">=16.0.0,<17.0.0"
+hrms = ">=16.0.0,<17.0.0"


### PR DESCRIPTION
Update the 'Project Configuration' to include 'ERPNext' and 'HRMS' as 'Required Dependencies', ensuring the environment correctly 'Resolves' and 'Installs' these core modules when setting up the project, maintaining 'Compatibility' with the 'Version Constraints' defined for the main application.

- Add erpnext to bench dependency list.
- Add hrms to bench dependency list.
- Ensure environment installs core modules correctly.
- Maintain version compatibility with main application.