### PR TITLE
chore: add ERPNext and HRMS as required dependencies in project configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,5 @@ docstring-code-format = true
 
 [tool.bench.frappe-dependencies]
 frappe = ">=16.0.0,<17.0.0"
+erpnext = ">=16.0.0,<17.0.0"
+hrms = ">=16.0.0,<17.0.0"


### PR DESCRIPTION
This pull request updates the dependency configuration in `pyproject.toml` to explicitly include version constraints for `erpnext` and `hrms` alongside `frappe`. This ensures that the project will only use compatible versions of these packages.

Dependency configuration updates:

* Added `erpnext` and `hrms` as required dependencies with version constraints matching `frappe` (>=16.0.0,<17.0.0) in the `[tool.bench.frappe-dependencies]` section of `pyproject.toml`.