### PR TITLE
fix: do not write an Error Log on every purchase submit when no price margins are configured

### DIFF
--- a/csf_ke/csf_ke/doctype/api/update_item_price_list.py
+++ b/csf_ke/csf_ke/doctype/api/update_item_price_list.py
@@ -23,9 +23,11 @@ def update_item_prices(doc, method):
 	# Fetch margin entries based on the currency and buying price list
 	margin_entries = get_margin_entries_and_details(currency, price_list)
 	if not margin_entries:
-		frappe.log_error(
-			f"No margin entries found for currency {currency} and buying price list {price_list}"
-		)
+		# No Selling Item Price Margin is configured for this currency / buying price
+		# list: the margin-pricing feature is simply not in use for this document, which
+		# is a normal state, not an error. Exit quietly — logging here writes one Error
+		# Log row per Purchase Receipt/Invoice submit on every site that does not use
+		# margin-based pricing.
 		return
 
 	margin_lookup = build_margin_lookup(margin_entries)


### PR DESCRIPTION
Fixes #331.

**What:** `update_item_prices` no longer calls `frappe.log_error` when `get_margin_entries_and_details` returns empty — it returns silently with a comment explaining why.

**Why:** the function is hooked on every Purchase Receipt / Purchase Invoice submit. On any site that does not configure `Selling Item Price Margin` (an optional feature), the empty branch fires on every purchase submit and writes an Error Log row each time — 1,000+ rows accumulated on one of our benches. Unconfigured is a normal state, not an error.

**Scope:** one branch only. Sites *using* margins see zero behaviour change; all other logging (including per-item "No applicable margins found", which after this change can only fire when margins are configured) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)