### PR TITLE
refactor(report): rebuild Kenya Purchase Tax Report on shared TaxReport base

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -601,6 +601,7 @@
     "etims",
     "Countryof",
     "iban",
-    "Unitof"
+    "Unitof",
+    "INVI"
   ]
 }

--- a/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.js
+++ b/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.js
@@ -1,6 +1,5 @@
 // Copyright (c) 2022, Navari Limited and contributors
 // For license information, please see license.txt
-/* eslint-disable */
 
 frappe.query_reports["Kenya Purchase Tax Report"] = {
   filters: [
@@ -9,136 +8,80 @@ frappe.query_reports["Kenya Purchase Tax Report"] = {
       label: __("Company"),
       fieldtype: "Link",
       options: "Company",
-      default: frappe.defaults.get_user_default("Company"),
-      width: "100px",
+      default: frappe.defaults.get_default("company"),
       reqd: 1,
     },
     {
       fieldname: "from_date",
-      label: __("Start Date"),
+      label: __("From Date"),
       fieldtype: "Date",
       default: frappe.datetime.add_months(frappe.datetime.get_today(), -1),
       reqd: 1,
-      width: "100px",
     },
     {
       fieldname: "to_date",
-      label: __("End Date"),
+      label: __("To Date"),
       fieldtype: "Date",
       default: frappe.datetime.get_today(),
       reqd: 1,
-      width: "100px",
+    },
+    {
+      fieldname: "item_tax_template",
+      label: __("Item Tax Template"),
+      fieldtype: "Link",
+      options: "Item Tax Template",
+      reqd: 0,
+      hidden: 1,
+    },
+    {
+      fieldname: "taxes_and_charges_template",
+      label: __("Purchase Taxes and Charges Template"),
+      fieldtype: "Link",
+      options: "Purchase Taxes and Charges Template",
+      reqd: 0,
+      hidden: 1,
     },
     {
       fieldname: "is_return",
       label: __("Is Return"),
-      fieldtype: "Select",
-      options: ["", "Is Return", "Normal Purchase Invoice"],
-      default: "",
+      fieldtype: "Check",
+      default: 0,
       reqd: 0,
-      width: "100px",
-    },
-    {
-      fieldname: "tax_template",
-      label: __("Tax Template"),
-      fieldtype: "Link",
-      options: "Item Tax Template",
-      reqd: 0,
-      width: "100px",
-    },
-    {
-      fieldname: "accounting_dimension",
-      label: __("Accounting Dimension"),
-      fieldtype: "Select",
-      options: ["", "Cost Center", "Project"],
-      default: "",
-      reqd: 0,
-      width: "120px",
     },
   ],
 
-  formatter: function (value, row, column, data, default_formatter) {
-    value = default_formatter(value, row, column, data);
-
-    // Bold formatting for group header rows
-    if (data && data.is_group_header) {
-      if (
-        [
-          "taxable_value",
-          "amount_of_vat",
-          "name_of_supplier",
-          "accounting_dimension_value",
-        ].includes(column.fieldname)
-      ) {
-        value = `<span style="font-weight: bold;">${value}</span>`;
-      }
-    }
-
-    return value;
-  },
-
   onload: function (report) {
     frappe.call({
-      method: "frappe.client.get_list",
+      method: "frappe.client.get_value",
       args: {
-        doctype: "Accounting Dimension",
-        fields: ["document_type"],
-        filters: {
-          disabled: 0,
-        },
+        doctype: "Accounts Settings",
+        fieldname: [
+          "add_taxes_from_item_tax_template",
+          "add_taxes_from_taxes_and_charges_template",
+        ],
       },
       callback: function (r) {
-        let options = ["", "Cost Center", "Project"];
         if (r.message) {
-          r.message.forEach(function (d) {
-            if (!options.includes(d.document_type)) {
-              options.push(d.document_type);
-            }
-          });
-        }
-        let dimension_filter = report.get_filter("accounting_dimension");
-        if (dimension_filter) {
-          dimension_filter.df.options = options;
-          dimension_filter.refresh();
+          const item_tax_template_filter =
+            report.get_filter("item_tax_template");
+          const taxes_and_charges_filter = report.get_filter(
+            "taxes_and_charges_template",
+          );
+          if (item_tax_template_filter) {
+            item_tax_template_filter.df.hidden =
+              !r.message.add_taxes_from_item_tax_template;
+            taxes_and_charges_filter.set_value("");
+            item_tax_template_filter.refresh();
+          }
+
+          if (taxes_and_charges_filter) {
+            taxes_and_charges_filter.df.hidden =
+              !r.message.add_taxes_from_taxes_and_charges_template;
+            item_tax_template_filter.set_value("");
+            taxes_and_charges_filter.refresh();
+          }
         }
       },
-    });
-
-    report.page.add_menu_item("Export CSVs", function () {
-      frappe.call({
-        method:
-          "csf_ke.csf_ke.report.kenya_purchase_tax_report.kenya_purchase_tax_report.download_custom_csv_format",
-        args: {
-          company: report.get_filter_value("company"),
-          from_date: report.get_filter_value("from_date"),
-          to_date: report.get_filter_value("to_date"),
-        },
-        callback: function (response) {
-          if (response.message) {
-            const fileLinks = Object.entries(response.message).map(
-              ([template, fileUrl]) => {
-                return `<a href="${fileUrl}" target="_blank">${template} Purchase Report</a>`;
-              },
-            );
-
-            // Display links in a modal
-            frappe.msgprint({
-              title: __("CSV Download Links"),
-              message: __(
-                "The files have been successfully generated. Redirecting to the File List...",
-              ),
-              indicator: "green",
-            });
-
-            // Redirect to the File List
-            frappe.set_route("List", "File", {
-              file_name: ["Like", `purchase`],
-            });
-          } else {
-            frappe.msgprint(__("No files were generated"));
-          }
-        },
-      });
     });
   },
 };

--- a/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.js
+++ b/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.js
@@ -42,6 +42,14 @@ frappe.query_reports["Kenya Purchase Tax Report"] = {
       hidden: 1,
     },
     {
+      fieldname: "accounting_dimension",
+      label: __("Accounting Dimension"),
+      fieldtype: "Select",
+      options: ["", "Cost Center", "Project"],
+      default: "",
+      reqd: 0,
+    },
+    {
       fieldname: "is_return",
       label: __("Is Return"),
       fieldtype: "Check",
@@ -49,6 +57,25 @@ frappe.query_reports["Kenya Purchase Tax Report"] = {
       reqd: 0,
     },
   ],
+
+  formatter: function (value, row, column, data, default_formatter) {
+    value = default_formatter(value, row, column, data);
+
+    if (data && data.is_group_header) {
+      if (
+        [
+          "accounting_dimension_value",
+          "party_name",
+          "taxable_amount",
+          "vat_amount",
+        ].includes(column.fieldname)
+      ) {
+        value = `<span style="font-weight: bold;">${value}</span>`;
+      }
+    }
+
+    return value;
+  },
 
   onload: function (report) {
     frappe.call({
@@ -82,6 +109,69 @@ frappe.query_reports["Kenya Purchase Tax Report"] = {
           }
         }
       },
+    });
+
+    frappe.call({
+      method: "frappe.client.get_list",
+      args: {
+        doctype: "Accounting Dimension",
+        fields: ["document_type"],
+        filters: {
+          disabled: 0,
+        },
+      },
+      callback: function (r) {
+        let options = ["", "Cost Center", "Project"];
+        if (r.message) {
+          r.message.forEach(function (d) {
+            if (!options.includes(d.document_type)) {
+              options.push(d.document_type);
+            }
+          });
+        }
+        let dimension_filter = report.get_filter("accounting_dimension");
+        if (dimension_filter) {
+          dimension_filter.df.options = options;
+          dimension_filter.refresh();
+        }
+      },
+    });
+
+    report.page.add_menu_item("Export CSVs", function () {
+      frappe.call({
+        method:
+          "csf_ke.csf_ke.report.kenya_purchase_tax_report.kenya_purchase_tax_report.download_custom_csv_format",
+        args: {
+          company: report.get_filter_value("company"),
+          from_date: report.get_filter_value("from_date"),
+          to_date: report.get_filter_value("to_date"),
+        },
+        callback: function (response) {
+          if (response.message) {
+            const fileLinks = Object.entries(response.message).map(
+              ([template, fileUrl]) => {
+                return `<a href="${fileUrl}" target="_blank">${template} Purchase Report</a>`;
+              },
+            );
+
+            // Display links in a modal
+            frappe.msgprint({
+              title: __("CSV Download Links"),
+              message: __(
+                "The files have been successfully generated. Redirecting to the File List...",
+              ),
+              indicator: "green",
+            });
+
+            // Redirect to the File List
+            frappe.set_route("List", "File", {
+              file_name: ["Like", `purchase`],
+            });
+          } else {
+            frappe.msgprint(__("No files were generated"));
+          }
+        },
+      });
     });
   },
 };

--- a/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.py
+++ b/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.py
@@ -2,63 +2,69 @@
 # For license information, please see license.txt
 
 
-import csv
-import os
-import re
-from collections import defaultdict
-from datetime import datetime
+from typing import TypedDict
 
-import frappe
 from frappe import _
 
-
-def execute(filters=None):
-	return KenyaPurchaseTaxReport(filters).run()
+from csf_ke.csf_ke.utils.tax_report import TaxReport
 
 
-class KenyaPurchaseTaxReport:
-	def __init__(self, filters=None):
-		self.filters = frappe._dict(filters or {})
-		self.registered_suppliers_total_purchases = 0
-		self.registered_suppliers_total_vat = 0
-		self.unregistered_suppliers_total_purchases = 0
-		self.unregistered_suppliers_total_vat = 0
+class KenyaPurchaseTaxReportFilters(TypedDict):
+	company: str | None
+	from_date: str | None
+	to_date: str | None
+	is_return: int | None
+	item_tax_template: str | None
+	taxes_and_charges_template: str | None
+
+
+def execute(filters: KenyaPurchaseTaxReportFilters | None = None):
+	report = KenyaPurchaseTaxReport(filters)
+	return report.run()
+
+
+class KenyaPurchaseTaxReport(TaxReport):
+	def __init__(self, filters: KenyaPurchaseTaxReportFilters | None = None):
+		super().__init__()
+		self.filters = filters or {}
+		self.company = self.filters.get("company")
+		self.from_date = self.filters.get("from_date")
+		self.to_date = self.filters.get("to_date")
+		self.item_tax_template = self.filters.get("item_tax_template")
+		self.taxes_and_charges_template = self.filters.get("taxes_and_charges_template")
 
 	def run(self):
 		columns = self.get_columns()
-		data = self.get_data()
-		report_summary = self.get_report_summary()
+		data = self.get_data("purchase")
 
-		return columns, data, None, None, report_summary
+		return columns, data, None, None, self.get_report_summary()
 
 	def get_columns(self):
-		columns = []
-
-		# Add accounting dimension column if filter is set
-		if self.filters.get("accounting_dimension"):
-			dimension_label = self.filters.get("accounting_dimension")
-			columns.append(
-				{
-					"label": _(dimension_label),
-					"fieldname": "accounting_dimension_value",
-					"fieldtype": "Link",
-					"options": dimension_label,
-					"width": 180,
-				}
-			)
-
-		columns += [
+		columns = [
 			{
-				"label": _("PIN of supplier"),
-				"fieldname": "pin_of_supplier",
+				"label": _("Supplier PIN"),
+				"fieldname": "tax_id",
 				"fieldtype": "Data",
-				"width": 160,
+				"width": 150,
 			},
 			{
-				"label": _("Name of supplier"),
-				"fieldname": "name_of_supplier",
+				"label": _("Supplier Name"),
+				"fieldname": "party_name",
 				"fieldtype": "Data",
-				"width": 240,
+				"width": 200,
+			},
+			{
+				"label": _("Invoice Number"),
+				"fieldname": "invoice_number",
+				"fieldtype": "Link",
+				"options": "Purchase Invoice",
+				"width": 200,
+			},
+			{
+				"label": _("Invoice Date"),
+				"fieldname": "invoice_date",
+				"fieldtype": "Date",
+				"width": 200,
 			},
 			{
 				"label": _("ETR Invoice Number"),
@@ -67,410 +73,80 @@ class KenyaPurchaseTaxReport:
 				"width": 200,
 			},
 			{
-				"label": _("Invoice Date"),
-				"fieldname": "invoice_date",
-				"fieldtype": "Date",
-				"width": 160,
-			},
-			{
-				"label": _("Invoice Number"),
-				"fieldname": "invoice_name",
-				"fieldtype": "Link",
-				"options": "Purchase Invoice",
-				"width": 200,
-			},
-			{
 				"label": _("Supplier Invoice No"),
-				"fieldname": "bill_no",
+				"fieldname": "supplier_invoice_no",
 				"fieldtype": "Data",
 				"width": 200,
 			},
 			{
 				"label": _("Supplier Invoice Date"),
-				"fieldname": "bill_date",
-				"fieldtype": "Data",
-				"width": 200,
-			},
-			{
-				"label": _("Taxable Value(Ksh)"),
-				"fieldname": "taxable_value",
-				"fieldtype": "Currency",
-				"width": 160,
-			},
-			{
-				"label": _("Amount of VAT(Ksh)"),
-				"fieldname": "amount_of_vat",
-				"fieldtype": "Currency",
-				"width": 160,
-			},
-			{
-				"label": _("Return CU Invoice Number"),
-				"fieldname": "return_cu_invoice_number",
-				"fieldtype": "Data",
-				"width": 200,
-			},
-			{
-				"label": _("Return CU Invoice Date"),
-				"fieldname": "return_cu_invoice_date",
+				"fieldname": "supplier_invoice_date",
 				"fieldtype": "Date",
-				"width": 160,
+				"width": 200,
+			},
+			{
+				"label": _("Taxable Amount"),
+				"fieldname": "taxable_amount",
+				"fieldtype": "Currency",
+				"options": "currency",
+				"width": 200,
+			},
+			{
+				"label": _("VAT Amount"),
+				"fieldname": "vat_amount",
+				"fieldtype": "Currency",
+				"options": "currency",
+				"width": 200,
+			},
+			{
+				"label": _("Currency"),
+				"fieldname": "currency",
+				"fieldtype": "Data",
+				"width": 200,
+				"hidden": 1,
 			},
 		]
 
-		if self.filters.is_return == "Is Return":
-			columns += [
+		if self.filters.get("is_return"):
+			columns.append(
 				{
 					"label": _("Return Against"),
 					"fieldname": "return_against",
-					"fieldtype": "Link",
-					"options": "Purchase Invoice",
+					"fieldtype": "Data",
 					"width": 200,
 				}
-			]
+			)
+
 		return columns
-
-	def get_purchase_invoices(self):
-		company = self.filters.company
-		from_date = self.filters.from_date
-		to_date = self.filters.to_date
-		is_return = self.filters.is_return
-
-		purchase_invoice_ = frappe.qb.DocType("Purchase Invoice")
-		supplier_ = frappe.qb.DocType("Supplier")
-
-		# Build select fields list
-		select_fields = [
-			supplier_.tax_id.as_("pin_of_supplier"),
-			purchase_invoice_.supplier_name.as_("name_of_supplier"),
-			purchase_invoice_.etr_invoice_number.as_("etr_invoice_number"),
-			purchase_invoice_.bill_date.as_("invoice_date"),
-			purchase_invoice_.name.as_("invoice_name"),
-			purchase_invoice_.bill_date.as_("bill_date"),
-			purchase_invoice_.bill_no.as_("bill_no"),
-			purchase_invoice_.base_grand_total.as_("invoice_total_purchases"),
-			purchase_invoice_.return_against.as_("return_against"),
-		]
-
-		# Add accounting dimension field if specified
-		accounting_dimension = self.filters.get("accounting_dimension")
-		if accounting_dimension:
-			dimension_field_map = {"Cost Center": "cost_center", "Project": "project"}
-			dimension_field = dimension_field_map.get(accounting_dimension)
-			if dimension_field:
-				select_fields.append(
-					getattr(purchase_invoice_, dimension_field).as_("accounting_dimension_value")
-				)
-
-		purchase_invoices_query = (
-			frappe.qb.from_(purchase_invoice_)
-			.inner_join(supplier_)
-			.on(purchase_invoice_.supplier == supplier_.name)
-			.select(*select_fields)
-			.where(purchase_invoice_.docstatus == 1)
-		)
-
-		if company:
-			purchase_invoices_query = purchase_invoices_query.where(purchase_invoice_.company == company)
-		if is_return == "Is Return":
-			purchase_invoices_query = purchase_invoices_query.where(purchase_invoice_.is_return == 1)
-		if is_return == "Normal Purchase Invoice":
-			purchase_invoices_query = purchase_invoices_query.where(purchase_invoice_.is_return == 0)
-		if from_date is not None:
-			purchase_invoices_query = purchase_invoices_query.where(
-				purchase_invoice_.posting_date >= from_date
-			)
-		if to_date:
-			purchase_invoices_query = purchase_invoices_query.where(purchase_invoice_.posting_date <= to_date)
-
-		purchase_invoices = purchase_invoices_query.run(as_dict=True)
-
-		for invoice in purchase_invoices:
-			if invoice.get("return_against"):
-				return_invoice_details = frappe.db.get_value(
-					"Purchase Invoice",
-					invoice["return_against"],
-					["etr_invoice_number", "bill_date"],
-					as_dict=True,
-				)
-				if return_invoice_details:
-					invoice["return_cu_invoice_number"] = return_invoice_details.get("etr_invoice_number")
-					invoice["return_cu_invoice_date"] = return_invoice_details.get("bill_date")
-
-		return purchase_invoices
-
-	def get_purchase_invoice_items(self, purchase_invoice_name, tax_template=None):
-		purchase_invoice_item_ = frappe.qb.DocType("Purchase Invoice Item")
-		purchase_invoice_items_query = (
-			frappe.qb.from_(purchase_invoice_item_)
-			.select(
-				purchase_invoice_item_.amount.as_("amount"),
-				purchase_invoice_item_.base_net_amount.as_("taxable_value"),
-				purchase_invoice_item_.item_tax_template.as_("item_tax_template"),
-			)
-			.where(purchase_invoice_item_.parent == purchase_invoice_name)
-		)
-
-		if tax_template:
-			purchase_invoice_items_query = purchase_invoice_items_query.where(
-				purchase_invoice_item_.item_tax_template == tax_template
-			)
-
-		items_or_services = purchase_invoice_items_query.run(as_dict=True)
-		return items_or_services
-
-	def get_data(self):
-		if self.filters.from_date > self.filters.to_date:
-			frappe.throw(_("To Date cannot be before From Date. {}").format(self.filters.to_date))
-
-		report_details = []
-
-		purchase_invoices = self.get_purchase_invoices()
-
-		for purchase_invoice in purchase_invoices:
-			items_or_services = self.get_purchase_invoice_items(
-				purchase_invoice.invoice_name, self.filters.tax_template
-			)
-
-			total_taxable_value = 0
-			total_vat = 0
-
-			for item_or_service in items_or_services:
-				tax_rate = frappe.db.get_value(
-					"Item Tax Template Detail",
-					{"parent": item_or_service["item_tax_template"]},
-					["tax_rate"],
-				)
-				item_or_service["amount_of_vat"] = (
-					0 if not tax_rate else item_or_service["taxable_value"] * (tax_rate / 100)
-				)
-
-				total_taxable_value += item_or_service["taxable_value"]
-				total_vat += item_or_service["amount_of_vat"]
-
-			purchase_invoice["taxable_value"] = total_taxable_value
-			purchase_invoice["amount_of_vat"] = total_vat
-
-			if total_taxable_value:
-				report_details.append(purchase_invoice)
-
-		for report_entry in report_details:
-			if report_entry["pin_of_supplier"]:
-				self.registered_suppliers_total_purchases += report_entry["taxable_value"]
-				self.registered_suppliers_total_vat += report_entry["amount_of_vat"]
-			else:
-				self.unregistered_suppliers_total_purchases += report_entry["taxable_value"]
-				self.unregistered_suppliers_total_vat += report_entry["amount_of_vat"]
-
-		if self.filters.get("accounting_dimension") and report_details:
-			report_details = self.group_by_dimension(report_details)
-
-		return report_details
-
-	def group_by_dimension(self, data):
-		"""Group data by accounting dimension and add group headers with totals"""
-		grouped_data = defaultdict(list)
-		for row in data:
-			dimension_value = row.get("accounting_dimension_value") or _("No Dimension")
-			grouped_data[dimension_value].append(row)
-
-		final_data = []
-		for dimension_value in sorted(grouped_data.keys()):
-			group_rows = grouped_data[dimension_value]
-
-			group_taxable_value = sum(row.get("taxable_value", 0) for row in group_rows)
-			group_amount_of_vat = sum(row.get("amount_of_vat", 0) for row in group_rows)
-
-			group_header = {
-				"accounting_dimension_value": dimension_value,
-				"taxable_value": group_taxable_value,
-				"amount_of_vat": group_amount_of_vat,
-				"is_group_header": True,
-			}
-			final_data.append(group_header)
-
-			for row in group_rows:
-				row["indent"] = 1
-				final_data.append(row)
-
-		return final_data
 
 	def get_report_summary(self):
 		return [
 			{
 				"value": self.registered_suppliers_total_purchases,
 				"indicator": "Green",
-				"label": _("Registered suppliers total purchases"),
+				"label": _("Registered Suppliers Total Purchases"),
 				"datatype": "Currency",
-				"currency": "KES",
+				"currency": self.currency,
 			},
 			{
 				"value": self.registered_suppliers_total_vat,
 				"indicator": "Green",
-				"label": _("Registered suppliers total VAT"),
+				"label": _("Registered Suppliers Total VAT"),
 				"datatype": "Currency",
-				"currency": "KES",
+				"currency": self.currency,
 			},
 			{
 				"value": self.unregistered_suppliers_total_purchases,
 				"indicator": "Green",
-				"label": _("Unregistered suppliers total purchases"),
+				"label": _("Unregistered Suppliers Total Purchases"),
 				"datatype": "Currency",
-				"currency": "KES",
+				"currency": self.currency,
 			},
 			{
 				"value": self.unregistered_suppliers_total_vat,
 				"indicator": "Green",
-				"label": _("Unregistered suppliers total VAT"),
+				"label": _("Unregistered Suppliers Total VAT"),
 				"datatype": "Currency",
-				"currency": "KES",
+				"currency": self.currency,
 			},
 		]
-
-
-def _normalize_companies(company):
-	if not company:
-		return frappe.get_all("Company", pluck="name")
-
-	if isinstance(company, str):
-		company = company.strip()
-		if not company:
-			return frappe.get_all("Company", pluck="name")
-
-		if company.startswith("["):
-			try:
-				parsed_companies = frappe.parse_json(company)
-			except Exception:
-				parsed_companies = None
-
-			if isinstance(parsed_companies, list):
-				return [item for item in parsed_companies if item]
-
-		if "," in company:
-			return [item.strip() for item in company.split(",") if item.strip()]
-
-		return [company]
-
-	if isinstance(company, (list, tuple, set)):
-		return [item for item in company if item]
-
-	return [company]
-
-
-def _get_tax_templates_from_report_data(company, from_date=None, to_date=None):
-	purchase_invoice_ = frappe.qb.DocType("Purchase Invoice")
-	purchase_invoice_item_ = frappe.qb.DocType("Purchase Invoice Item")
-
-	tax_templates_query = (
-		frappe.qb.from_(purchase_invoice_item_)
-		.inner_join(purchase_invoice_)
-		.on(purchase_invoice_item_.parent == purchase_invoice_.name)
-		.select(purchase_invoice_item_.item_tax_template)
-		.distinct()
-		.where(purchase_invoice_.docstatus == 1)
-		.where(purchase_invoice_.company == company)
-	)
-
-	if from_date:
-		tax_templates_query = tax_templates_query.where(purchase_invoice_.posting_date >= from_date)
-	if to_date:
-		tax_templates_query = tax_templates_query.where(purchase_invoice_.posting_date <= to_date)
-
-	tax_template_rows = tax_templates_query.run(as_dict=True)
-	return sorted({row.get("item_tax_template") for row in tax_template_rows if row.get("item_tax_template")})
-
-
-@frappe.whitelist()
-def download_custom_csv_format(company: str, from_date: str | None = None, to_date: str | None = None):
-	if not from_date:
-		frappe.throw(_("From Date is required"))
-	if not to_date:
-		frappe.throw(_("To Date is required"))
-
-	from_date_str = from_date.strftime("%y-%m-%d") if isinstance(from_date, datetime) else from_date
-	to_date_str = to_date.strftime("%y-%m-%d") if isinstance(to_date, datetime) else to_date
-
-	private_path = frappe.utils.get_site_path("private", "files")
-	os.makedirs(private_path, exist_ok=True)
-
-	companies = _normalize_companies(company)
-	if not companies:
-		frappe.throw(_("At least one company is required"))
-
-	csv_files = {}
-
-	timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-
-	for company_name in companies:
-		tax_templates = _get_tax_templates_from_report_data(company_name, from_date, to_date)
-		if not tax_templates:
-			continue
-
-		company_abbr = frappe.db.get_value("Company", company_name, "abbr") or ""
-
-		for template_name in tax_templates:
-			sanitized_template_name = re.sub(r"[^\w]+", "_", template_name).lower()
-
-			csv_file_name = f"purchase_{sanitized_template_name[:20]}_{company_abbr}_{from_date_str}_to_{to_date_str}_{timestamp}.csv".strip(
-				"_"
-			)
-
-			full_file_path = os.path.join(private_path, csv_file_name)
-			file_url = f"/private/files/{csv_file_name}"
-
-			purchase_invoices = KenyaPurchaseTaxReport(
-				{
-					"company": company_name,
-					"from_date": from_date,
-					"to_date": to_date,
-					"tax_template": template_name,
-				}
-			).get_data()
-
-			if not purchase_invoices:
-				continue
-
-			with open(full_file_path, "w", newline="") as csvfile:
-				writer = csv.writer(csvfile)
-
-				for invoice in purchase_invoices:
-					if invoice.get("pin_of_supplier"):
-						writer.writerow(
-							[
-								"Local",
-								invoice.get("pin_of_supplier", ""),
-								invoice.get("name_of_supplier", ""),
-								invoice.get("bill_date").strftime("%d/%m/%Y")
-								if invoice.get("bill_date")
-								else "",
-								f"|{(invoice.get('etr_invoice_number', ''))}",
-								invoice.get("bill_no", ""),
-								"",
-								invoice.get("taxable_value", ""),
-								"",
-								f"{'|' + invoice.get('return_cu_invoice_number', '') if invoice.return_against else ''}",
-								(
-									invoice.get("return_cu_invoice_date").strftime("%d/%m/%Y")
-									if invoice.return_against and invoice.get("return_cu_invoice_date")
-									else ""
-								),
-							]
-						)
-
-			file_record = frappe.get_doc(
-				{
-					"doctype": "File",
-					"file_name": csv_file_name,
-					"file_url": file_url,
-					"attached_to_name": company_name,
-					"attached_to_doctype": "Purchase Invoice",
-					"file_size": os.path.getsize(full_file_path),
-					"is_private": 1,
-					"file_type": "CSV",
-				}
-			)
-			file_record.insert()
-
-			display_key = f"{company_name} - {template_name}" if len(companies) > 1 else template_name
-			csv_files[display_key] = file_url
-
-	return csv_files

--- a/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.py
+++ b/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2022, Navari Limited and contributors
 # For license information, please see license.txt
 
-
+import csv
+import os
+import re
+from datetime import datetime
 from typing import TypedDict
 
+import frappe
 from frappe import _
 
 from csf_ke.csf_ke.utils.tax_report import TaxReport
@@ -16,6 +20,7 @@ class KenyaPurchaseTaxReportFilters(TypedDict):
 	is_return: int | None
 	item_tax_template: str | None
 	taxes_and_charges_template: str | None
+	accounting_dimension: str | None
 
 
 def execute(filters: KenyaPurchaseTaxReportFilters | None = None):
@@ -105,16 +110,38 @@ class KenyaPurchaseTaxReport(TaxReport):
 				"width": 200,
 				"hidden": 1,
 			},
+			{
+				"label": _("Original CU Invoice Number"),
+				"fieldname": "original_cu_invoice_number",
+				"fieldtype": "Data",
+				"width": 200,
+			},
+			{
+				"label": _("Original CU Invoice Date"),
+				"fieldname": "original_cu_invoice_date",
+				"fieldtype": "Date",
+				"width": 200,
+			},
+			{
+				"label": _("Return Against"),
+				"fieldname": "return_against",
+				"fieldtype": "Link",
+				"options": "Purchase Invoice",
+				"width": 200,
+			},
 		]
 
-		if self.filters.get("is_return"):
-			columns.append(
+		if self.filters.get("accounting_dimension"):
+			dimension = self.filters.get("accounting_dimension")
+			columns.insert(
+				0,
 				{
-					"label": _("Return Against"),
-					"fieldname": "return_against",
-					"fieldtype": "Data",
+					"label": _(dimension),
+					"fieldname": "accounting_dimension_value",
+					"fieldtype": "Link",
+					"options": dimension,
 					"width": 200,
-				}
+				},
 			)
 
 		return columns
@@ -150,3 +177,155 @@ class KenyaPurchaseTaxReport(TaxReport):
 				"currency": self.currency,
 			},
 		]
+
+
+def _normalize_companies(company):
+	if not company:
+		return frappe.get_all("Company", pluck="name")
+
+	if isinstance(company, str):
+		company = company.strip()
+		if not company:
+			return frappe.get_all("Company", pluck="name")
+
+		if company.startswith("["):
+			try:
+				parsed_companies = frappe.parse_json(company)
+			except Exception:
+				parsed_companies = None
+
+			if isinstance(parsed_companies, list):
+				return [item for item in parsed_companies if item]
+
+		if "," in company:
+			return [item.strip() for item in company.split(",") if item.strip()]
+
+		return [company]
+
+	if isinstance(company, (list, tuple, set)):
+		return [item for item in company if item]
+
+	return [company]
+
+
+def _get_tax_templates_from_report_data(company, from_date=None, to_date=None):
+	purchase_invoice_ = frappe.qb.DocType("Purchase Invoice")
+	purchase_invoice_item_ = frappe.qb.DocType("Purchase Invoice Item")
+
+	tax_templates_query = (
+		frappe.qb.from_(purchase_invoice_item_)
+		.inner_join(purchase_invoice_)
+		.on(purchase_invoice_item_.parent == purchase_invoice_.name)
+		.select(purchase_invoice_item_.item_tax_template)
+		.distinct()
+		.where(purchase_invoice_.docstatus == 1)
+		.where(purchase_invoice_.company == company)
+	)
+
+	if from_date:
+		tax_templates_query = tax_templates_query.where(purchase_invoice_.posting_date >= from_date)
+	if to_date:
+		tax_templates_query = tax_templates_query.where(purchase_invoice_.posting_date <= to_date)
+
+	tax_template_rows = tax_templates_query.run(as_dict=True)
+	return sorted({row.get("item_tax_template") for row in tax_template_rows if row.get("item_tax_template")})
+
+
+@frappe.whitelist()
+def download_custom_csv_format(company: str, from_date: str | None = None, to_date: str | None = None):
+	if not from_date:
+		frappe.throw(_("From Date is required"))
+	if not to_date:
+		frappe.throw(_("To Date is required"))
+
+	from_date_str = from_date.strftime("%y-%m-%d") if isinstance(from_date, datetime) else from_date
+	to_date_str = to_date.strftime("%y-%m-%d") if isinstance(to_date, datetime) else to_date
+
+	private_path = frappe.utils.get_site_path("private", "files")
+	os.makedirs(private_path, exist_ok=True)
+
+	companies = _normalize_companies(company)
+	if not companies:
+		frappe.throw(_("At least one company is required"))
+
+	csv_files = {}
+
+	timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+	for company_name in companies:
+		tax_templates = _get_tax_templates_from_report_data(company_name, from_date, to_date)
+		if not tax_templates:
+			continue
+
+		company_abbr = frappe.db.get_value("Company", company_name, "abbr") or ""
+
+		for template_name in tax_templates:
+			sanitized_template_name = re.sub(r"[^\w]+", "_", template_name).lower()
+
+			csv_file_name = f"purchase_{sanitized_template_name[:20]}_{company_abbr}_{from_date_str}_to_{to_date_str}_{timestamp}.csv".strip(
+				"_"
+			)
+
+			full_file_path = os.path.join(private_path, csv_file_name)
+			file_url = f"/private/files/{csv_file_name}"
+
+			purchase_invoices = KenyaPurchaseTaxReport(
+				{
+					"company": company_name,
+					"from_date": from_date,
+					"to_date": to_date,
+					"item_tax_template": template_name,
+				}
+			).get_data("purchase")
+
+			if not purchase_invoices:
+				continue
+
+			with open(full_file_path, "w", newline="") as csvfile:
+				writer = csv.writer(csvfile)
+
+				for invoice in purchase_invoices:
+					if invoice.get("tax_id"):
+						writer.writerow(
+							[
+								"Local",
+								invoice.get("tax_id", ""),
+								invoice.get("party_name", ""),
+								(
+									invoice.get("invoice_date").strftime("%d/%m/%Y")
+									if invoice.get("invoice_date")
+									else ""
+								),
+								f"|{(invoice.get('etr_invoice_number', ''))}",
+								invoice.get("invoice_number", ""),
+								"",
+								invoice.get("taxable_amount", ""),
+								"",
+								f"{'|' + invoice.get('original_cu_invoice_number', '') if invoice.get('return_against') else ''}",
+								(
+									invoice.get("original_cu_invoice_date").strftime("%d/%m/%Y")
+									if invoice.get("return_against")
+									and invoice.get("original_cu_invoice_date")
+									else ""
+								),
+							]
+						)
+
+			file_record = frappe.get_doc(
+				{
+					"doctype": "File",
+					"file_name": csv_file_name,
+					"file_url": file_url,
+					"attached_to_name": company_name,
+					"attached_to_doctype": "Purchase Invoice",
+					"file_size": os.path.getsize(full_file_path),
+					"is_private": 1,
+					"file_type": "CSV",
+				}
+			)
+			file_record.insert()
+
+			display_key = f"{company_name} - {template_name}" if len(companies) > 1 else template_name
+			csv_files[display_key] = file_url
+
+	return csv_files

--- a/csf_ke/csf_ke/utils/tax_report.py
+++ b/csf_ke/csf_ke/utils/tax_report.py
@@ -1,0 +1,142 @@
+from abc import ABC, abstractmethod
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+
+class TaxReport(ABC):
+	def __init__(self):
+		self.registered_suppliers_total_purchases = 0.0
+		self.registered_suppliers_total_vat = 0.0
+		self.unregistered_suppliers_total_purchases = 0.0
+		self.unregistered_suppliers_total_vat = 0.0
+		self.currency = None
+
+	@abstractmethod
+	def get_columns(self):
+		"""Return the report column definitions (names, labels, types)"""
+
+	@abstractmethod
+	def get_report_summary(self):
+		"""Return the report summary"""
+
+	def get_data(self, invoice_type):
+		data = []
+		invoice_data = self.get_invoice_data(invoice_type)
+		if invoice_data:
+			data = self.process_invoice_data(invoice_data, invoice_type)
+		return data
+
+	def get_invoice_data(self, invoice_type):
+		INV = (
+			frappe.qb.DocType("Sales Invoice")
+			if invoice_type == "sales"
+			else frappe.qb.DocType("Purchase Invoice")
+		)
+		INVI = (
+			frappe.qb.DocType("Sales Invoice Item")
+			if invoice_type == "sales"
+			else frappe.qb.DocType("Purchase Invoice Item")
+		)
+		TD = frappe.qb.DocType("Item Wise Tax Detail")
+
+		query = (
+			frappe.qb.from_(TD)
+			.inner_join(INV)
+			.on(TD.parent == INV.name)
+			.inner_join(INVI)
+			.on((INVI.parent == INV.name) & (INVI.name == TD.item_row))
+			.select(
+				INV.supplier if invoice_type == "purchase" else INV.customer,
+				INV.supplier_name if invoice_type == "purchase" else INV.customer_name,
+				INV.tax_id,
+				INV.name.as_("invoice_number"),
+				INV.posting_date.as_("invoice_date"),
+				INV.return_against,
+				INV.etr_invoice_number,
+				TD.item_row,
+				TD.amount,
+				TD.rate,
+				TD.taxable_amount,
+			)
+			.where(INV.docstatus == 1)
+			# .where(TD.rate != 0)
+		)
+
+		if invoice_type == "purchase":
+			query = query.select(
+				INV.bill_no.as_("supplier_invoice_no"),
+				INV.bill_date.as_("supplier_invoice_date"),
+			)
+
+		if self.filters.get("company"):
+			query = query.where(INV.company == self.filters.get("company"))
+
+		if self.filters.get("from_date"):
+			query = query.where(INV.posting_date >= self.filters.get("from_date"))
+
+		if self.filters.get("to_date"):
+			query = query.where(INV.posting_date <= self.filters.get("to_date"))
+
+		if self.filters.get("item_tax_template"):
+			query = query.where(INVI.item_tax_template == self.filters.get("item_tax_template"))
+
+		if self.filters.get("taxes_and_charges_template"):
+			query = query.where(INV.taxes_and_charges == self.filters.get("taxes_and_charges_template"))
+
+		if self.filters.get("is_return"):
+			query = query.where(INV.is_return == self.filters.get("is_return"))
+
+		return query.run(as_dict=True)
+
+	def process_invoice_data(self, invoice_data, invoice_type):
+		self.currency = frappe.db.get_value("Company", self.filters.get("company"), "default_currency")
+		party_field = "supplier" if invoice_type == "purchase" else "customer"
+		party_name_field = "supplier_name" if invoice_type == "purchase" else "customer_name"
+
+		invoice_map = {}
+		seen_items = {}
+
+		for row in invoice_data:
+			invoice_number = row.get("invoice_number")
+			item_row = row.get("item_row")
+
+			if invoice_number not in invoice_map:
+				invoice_map[invoice_number] = {
+					"party": row.get(party_field),
+					"party_name": row.get(party_name_field),
+					"tax_id": row.get("tax_id"),
+					"invoice_number": invoice_number,
+					"invoice_date": row.get("invoice_date"),
+					"return_against": row.get("return_against"),
+					"supplier_invoice_no": row.get("supplier_invoice_no"),
+					"supplier_invoice_date": row.get("supplier_invoice_date"),
+					"etr_invoice_number": row.get("etr_invoice_number"),
+					"taxable_amount": 0.0,
+					"vat_amount": 0.0,
+					"currency": self.currency,
+				}
+				seen_items[invoice_number] = set()
+
+			invoice_map[invoice_number]["vat_amount"] += flt(row.get("amount", 0))
+
+			if party_field == "supplier":
+				if row.get("tax_id"):
+					self.registered_suppliers_total_vat += flt(row.get("amount", 0))
+				else:
+					self.unregistered_suppliers_total_vat += flt(row.get("amount", 0))
+
+			# Taxable amount is per item; only count it once when an item has
+			# multiple tax rows (e.g. VAT + another charge on the same base).
+			if item_row not in seen_items[invoice_number] and not (row.get("amount")) < 0:
+				invoice_map[invoice_number]["taxable_amount"] += flt(row.get("taxable_amount", 0))
+				seen_items[invoice_number].add(item_row)
+
+				if party_field == "supplier":
+					if row.get("tax_id"):
+						self.registered_suppliers_total_purchases += flt(row.get("taxable_amount", 0))
+					else:
+						self.unregistered_suppliers_total_purchases += flt(row.get("taxable_amount", 0))
+
+		return list(invoice_map.values())

--- a/csf_ke/csf_ke/utils/tax_report.py
+++ b/csf_ke/csf_ke/utils/tax_report.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections import defaultdict
 
 import frappe
 from frappe import _
@@ -26,19 +27,15 @@ class TaxReport(ABC):
 		invoice_data = self.get_invoice_data(invoice_type)
 		if invoice_data:
 			data = self.process_invoice_data(invoice_data, invoice_type)
+			if self.filters.get("accounting_dimension") and data:
+				data = self.group_by_dimension(data)
 		return data
 
 	def get_invoice_data(self, invoice_type):
-		INV = (
-			frappe.qb.DocType("Sales Invoice")
-			if invoice_type == "sales"
-			else frappe.qb.DocType("Purchase Invoice")
-		)
-		INVI = (
-			frappe.qb.DocType("Sales Invoice Item")
-			if invoice_type == "sales"
-			else frappe.qb.DocType("Purchase Invoice Item")
-		)
+		invoice_doctype = "Sales Invoice" if invoice_type == "sales" else "Purchase Invoice"
+		item_doctype = f"{invoice_doctype} Item"
+		INV = frappe.qb.DocType(invoice_doctype)
+		INVI = frappe.qb.DocType(item_doctype)
 		TD = frappe.qb.DocType("Item Wise Tax Detail")
 
 		query = (
@@ -70,6 +67,10 @@ class TaxReport(ABC):
 				INV.bill_date.as_("supplier_invoice_date"),
 			)
 
+		# TODO: handle invoice_type = sales
+
+		query = self._select_accounting_dimension(query, INV, invoice_doctype)
+
 		if self.filters.get("company"):
 			query = query.where(INV.company == self.filters.get("company"))
 
@@ -90,13 +91,26 @@ class TaxReport(ABC):
 
 		return query.run(as_dict=True)
 
+	def _select_accounting_dimension(self, query, INV, invoice_doctype):
+		accounting_dimension = self.filters.get("accounting_dimension")
+		if not accounting_dimension:
+			return query
+
+		fieldname = frappe.scrub(accounting_dimension)
+		if frappe.get_meta(invoice_doctype).has_field(fieldname):
+			return query.select(getattr(INV, fieldname).as_("accounting_dimension_value"))
+
+		return query
+
 	def process_invoice_data(self, invoice_data, invoice_type):
 		self.currency = frappe.db.get_value("Company", self.filters.get("company"), "default_currency")
 		party_field = "supplier" if invoice_type == "purchase" else "customer"
 		party_name_field = "supplier_name" if invoice_type == "purchase" else "customer_name"
+		group_by_dimension = bool(self.filters.get("accounting_dimension"))
 
 		invoice_map = {}
 		seen_items = {}
+		return_against_map = {}
 
 		for row in invoice_data:
 			invoice_number = row.get("invoice_number")
@@ -117,6 +131,16 @@ class TaxReport(ABC):
 					"vat_amount": 0.0,
 					"currency": self.currency,
 				}
+
+				if row.get("return_against"):
+					return_against_map[row.get("return_against")] = {
+						"invoice_number": row.get("return_against"),
+					}
+
+				if group_by_dimension:
+					invoice_map[invoice_number]["accounting_dimension_value"] = row.get(
+						"accounting_dimension_value"
+					)
 				seen_items[invoice_number] = set()
 
 			invoice_map[invoice_number]["vat_amount"] += flt(row.get("amount", 0))
@@ -129,7 +153,10 @@ class TaxReport(ABC):
 
 			# Taxable amount is per item; only count it once when an item has
 			# multiple tax rows (e.g. VAT + another charge on the same base).
-			if item_row not in seen_items[invoice_number] and not (row.get("amount")) < 0:
+			if (
+				item_row not in seen_items[invoice_number]
+				# and not (row.get("amount")) == 0
+			):
 				invoice_map[invoice_number]["taxable_amount"] += flt(row.get("taxable_amount", 0))
 				seen_items[invoice_number].add(item_row)
 
@@ -139,4 +166,70 @@ class TaxReport(ABC):
 					else:
 						self.unregistered_suppliers_total_purchases += flt(row.get("taxable_amount", 0))
 
+		if invoice_type == "purchase":
+			INV = frappe.qb.DocType("Purchase Invoice")
+			if return_against_map:
+				query = (
+					frappe.qb.from_(INV)
+					.select(
+						INV.name,
+						INV.etr_invoice_number,
+						INV.bill_date,
+						INV.posting_date,
+					)
+					.where(INV.name.isin(list(return_against_map.keys())))
+					.where(INV.etr_invoice_number.isnotnull())
+				)
+				data = query.run(as_dict=True)
+				for row in data:
+					return_against_map[row.name] = {
+						"original_cu_invoice_number": row.etr_invoice_number,
+						"original_cu_invoice_date": row.get("bill_date", row.get("posting_date")),
+					}
+
+			if invoice_map and return_against_map:
+				for __, invoice_data in invoice_map.items():
+					if (
+						invoice_data.get("return_against")
+						and return_against_map.get(invoice_data.get("return_against"))
+						and return_against_map.get(invoice_data.get("return_against")).get(
+							"original_cu_invoice_number"
+						)
+					):
+						invoice_data["original_cu_invoice_number"] = return_against_map[
+							invoice_data.get("return_against")
+						].get("original_cu_invoice_number")
+						invoice_data["original_cu_invoice_date"] = return_against_map[
+							invoice_data.get("return_against")
+						].get("original_cu_invoice_date")
+
+		# TODO: handle invoice_type = sales
+
 		return list(invoice_map.values())
+
+	def group_by_dimension(self, data):
+		"""Group rows by accounting dimension with header totals per group."""
+		grouped_data = defaultdict(list)
+		for row in data:
+			dimension_value = row.get("accounting_dimension_value") or _("No Dimension")
+			# row["accounting_dimension_value"] = dimension_value
+			grouped_data[dimension_value].append(row)
+
+		final_data = []
+		for dimension_value in sorted(grouped_data.keys()):
+			group_rows = grouped_data[dimension_value]
+			final_data.append(
+				{
+					"accounting_dimension_value": dimension_value,
+					"party_name": None,
+					"taxable_amount": sum(flt(row.get("taxable_amount")) for row in group_rows),
+					"vat_amount": sum(flt(row.get("vat_amount")) for row in group_rows),
+					"currency": self.currency,
+					"is_group_header": True,
+				}
+			)
+			for row in group_rows:
+				row["indent"] = 1
+				final_data.append(row)
+
+		return final_data


### PR DESCRIPTION


Rationale: Some purchase invoices with VAT were excluded because the old report relied on incomplete tax sources.

- Rebuild on Item Wise Tax Detail via a shared TaxReport base so those invoices are included, and so purchase (and future sales) reports can share taxable/VAT aggregation and registered vs unregistered supplier summaries.

- Simplify the purchase report UI: checkbox for is_return, Item Tax Template / Purchase Taxes and Charges Template filters driven by Accounts Settings