### PR TITLE
Refactor Kenya Purchase Tax Report, Simplify Filters, and Prevent Unnecessary Error Logs

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -601,6 +601,7 @@
     "etims",
     "Countryof",
     "iban",
-    "Unitof"
+    "Unitof",
+    "INVI"
   ]
 }

--- a/csf_ke/csf_ke/doctype/api/update_item_price_list.py
+++ b/csf_ke/csf_ke/doctype/api/update_item_price_list.py
@@ -23,9 +23,11 @@ def update_item_prices(doc, method):
 	# Fetch margin entries based on the currency and buying price list
 	margin_entries = get_margin_entries_and_details(currency, price_list)
 	if not margin_entries:
-		frappe.log_error(
-			f"No margin entries found for currency {currency} and buying price list {price_list}"
-		)
+		# No Selling Item Price Margin is configured for this currency / buying price
+		# list: the margin-pricing feature is simply not in use for this document, which
+		# is a normal state, not an error. Exit quietly — logging here writes one Error
+		# Log row per Purchase Receipt/Invoice submit on every site that does not use
+		# margin-based pricing.
 		return
 
 	margin_lookup = build_margin_lookup(margin_entries)

--- a/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.js
+++ b/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.js
@@ -1,6 +1,5 @@
 // Copyright (c) 2022, Navari Limited and contributors
 // For license information, please see license.txt
-/* eslint-disable */
 
 frappe.query_reports["Kenya Purchase Tax Report"] = {
   filters: [
@@ -9,136 +8,80 @@ frappe.query_reports["Kenya Purchase Tax Report"] = {
       label: __("Company"),
       fieldtype: "Link",
       options: "Company",
-      default: frappe.defaults.get_user_default("Company"),
-      width: "100px",
+      default: frappe.defaults.get_default("company"),
       reqd: 1,
     },
     {
       fieldname: "from_date",
-      label: __("Start Date"),
+      label: __("From Date"),
       fieldtype: "Date",
       default: frappe.datetime.add_months(frappe.datetime.get_today(), -1),
       reqd: 1,
-      width: "100px",
     },
     {
       fieldname: "to_date",
-      label: __("End Date"),
+      label: __("To Date"),
       fieldtype: "Date",
       default: frappe.datetime.get_today(),
       reqd: 1,
-      width: "100px",
+    },
+    {
+      fieldname: "item_tax_template",
+      label: __("Item Tax Template"),
+      fieldtype: "Link",
+      options: "Item Tax Template",
+      reqd: 0,
+      hidden: 1,
+    },
+    {
+      fieldname: "taxes_and_charges_template",
+      label: __("Purchase Taxes and Charges Template"),
+      fieldtype: "Link",
+      options: "Purchase Taxes and Charges Template",
+      reqd: 0,
+      hidden: 1,
     },
     {
       fieldname: "is_return",
       label: __("Is Return"),
-      fieldtype: "Select",
-      options: ["", "Is Return", "Normal Purchase Invoice"],
-      default: "",
+      fieldtype: "Check",
+      default: 0,
       reqd: 0,
-      width: "100px",
-    },
-    {
-      fieldname: "tax_template",
-      label: __("Tax Template"),
-      fieldtype: "Link",
-      options: "Item Tax Template",
-      reqd: 0,
-      width: "100px",
-    },
-    {
-      fieldname: "accounting_dimension",
-      label: __("Accounting Dimension"),
-      fieldtype: "Select",
-      options: ["", "Cost Center", "Project"],
-      default: "",
-      reqd: 0,
-      width: "120px",
     },
   ],
 
-  formatter: function (value, row, column, data, default_formatter) {
-    value = default_formatter(value, row, column, data);
-
-    // Bold formatting for group header rows
-    if (data && data.is_group_header) {
-      if (
-        [
-          "taxable_value",
-          "amount_of_vat",
-          "name_of_supplier",
-          "accounting_dimension_value",
-        ].includes(column.fieldname)
-      ) {
-        value = `<span style="font-weight: bold;">${value}</span>`;
-      }
-    }
-
-    return value;
-  },
-
   onload: function (report) {
     frappe.call({
-      method: "frappe.client.get_list",
+      method: "frappe.client.get_value",
       args: {
-        doctype: "Accounting Dimension",
-        fields: ["document_type"],
-        filters: {
-          disabled: 0,
-        },
+        doctype: "Accounts Settings",
+        fieldname: [
+          "add_taxes_from_item_tax_template",
+          "add_taxes_from_taxes_and_charges_template",
+        ],
       },
       callback: function (r) {
-        let options = ["", "Cost Center", "Project"];
         if (r.message) {
-          r.message.forEach(function (d) {
-            if (!options.includes(d.document_type)) {
-              options.push(d.document_type);
-            }
-          });
-        }
-        let dimension_filter = report.get_filter("accounting_dimension");
-        if (dimension_filter) {
-          dimension_filter.df.options = options;
-          dimension_filter.refresh();
+          const item_tax_template_filter =
+            report.get_filter("item_tax_template");
+          const taxes_and_charges_filter = report.get_filter(
+            "taxes_and_charges_template",
+          );
+          if (item_tax_template_filter) {
+            item_tax_template_filter.df.hidden =
+              !r.message.add_taxes_from_item_tax_template;
+            taxes_and_charges_filter.set_value("");
+            item_tax_template_filter.refresh();
+          }
+
+          if (taxes_and_charges_filter) {
+            taxes_and_charges_filter.df.hidden =
+              !r.message.add_taxes_from_taxes_and_charges_template;
+            item_tax_template_filter.set_value("");
+            taxes_and_charges_filter.refresh();
+          }
         }
       },
-    });
-
-    report.page.add_menu_item("Export CSVs", function () {
-      frappe.call({
-        method:
-          "csf_ke.csf_ke.report.kenya_purchase_tax_report.kenya_purchase_tax_report.download_custom_csv_format",
-        args: {
-          company: report.get_filter_value("company"),
-          from_date: report.get_filter_value("from_date"),
-          to_date: report.get_filter_value("to_date"),
-        },
-        callback: function (response) {
-          if (response.message) {
-            const fileLinks = Object.entries(response.message).map(
-              ([template, fileUrl]) => {
-                return `<a href="${fileUrl}" target="_blank">${template} Purchase Report</a>`;
-              },
-            );
-
-            // Display links in a modal
-            frappe.msgprint({
-              title: __("CSV Download Links"),
-              message: __(
-                "The files have been successfully generated. Redirecting to the File List...",
-              ),
-              indicator: "green",
-            });
-
-            // Redirect to the File List
-            frappe.set_route("List", "File", {
-              file_name: ["Like", `purchase`],
-            });
-          } else {
-            frappe.msgprint(__("No files were generated"));
-          }
-        },
-      });
     });
   },
 };

--- a/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.js
+++ b/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.js
@@ -42,6 +42,14 @@ frappe.query_reports["Kenya Purchase Tax Report"] = {
       hidden: 1,
     },
     {
+      fieldname: "accounting_dimension",
+      label: __("Accounting Dimension"),
+      fieldtype: "Select",
+      options: ["", "Cost Center", "Project"],
+      default: "",
+      reqd: 0,
+    },
+    {
       fieldname: "is_return",
       label: __("Is Return"),
       fieldtype: "Check",
@@ -49,6 +57,25 @@ frappe.query_reports["Kenya Purchase Tax Report"] = {
       reqd: 0,
     },
   ],
+
+  formatter: function (value, row, column, data, default_formatter) {
+    value = default_formatter(value, row, column, data);
+
+    if (data && data.is_group_header) {
+      if (
+        [
+          "accounting_dimension_value",
+          "party_name",
+          "taxable_amount",
+          "vat_amount",
+        ].includes(column.fieldname)
+      ) {
+        value = `<span style="font-weight: bold;">${value}</span>`;
+      }
+    }
+
+    return value;
+  },
 
   onload: function (report) {
     frappe.call({
@@ -82,6 +109,69 @@ frappe.query_reports["Kenya Purchase Tax Report"] = {
           }
         }
       },
+    });
+
+    frappe.call({
+      method: "frappe.client.get_list",
+      args: {
+        doctype: "Accounting Dimension",
+        fields: ["document_type"],
+        filters: {
+          disabled: 0,
+        },
+      },
+      callback: function (r) {
+        let options = ["", "Cost Center", "Project"];
+        if (r.message) {
+          r.message.forEach(function (d) {
+            if (!options.includes(d.document_type)) {
+              options.push(d.document_type);
+            }
+          });
+        }
+        let dimension_filter = report.get_filter("accounting_dimension");
+        if (dimension_filter) {
+          dimension_filter.df.options = options;
+          dimension_filter.refresh();
+        }
+      },
+    });
+
+    report.page.add_menu_item("Export CSVs", function () {
+      frappe.call({
+        method:
+          "csf_ke.csf_ke.report.kenya_purchase_tax_report.kenya_purchase_tax_report.download_custom_csv_format",
+        args: {
+          company: report.get_filter_value("company"),
+          from_date: report.get_filter_value("from_date"),
+          to_date: report.get_filter_value("to_date"),
+        },
+        callback: function (response) {
+          if (response.message) {
+            const fileLinks = Object.entries(response.message).map(
+              ([template, fileUrl]) => {
+                return `<a href="${fileUrl}" target="_blank">${template} Purchase Report</a>`;
+              },
+            );
+
+            // Display links in a modal
+            frappe.msgprint({
+              title: __("CSV Download Links"),
+              message: __(
+                "The files have been successfully generated. Redirecting to the File List...",
+              ),
+              indicator: "green",
+            });
+
+            // Redirect to the File List
+            frappe.set_route("List", "File", {
+              file_name: ["Like", `purchase`],
+            });
+          } else {
+            frappe.msgprint(__("No files were generated"));
+          }
+        },
+      });
     });
   },
 };

--- a/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.py
+++ b/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.py
@@ -2,63 +2,69 @@
 # For license information, please see license.txt
 
 
-import csv
-import os
-import re
-from collections import defaultdict
-from datetime import datetime
+from typing import TypedDict
 
-import frappe
 from frappe import _
 
-
-def execute(filters=None):
-	return KenyaPurchaseTaxReport(filters).run()
+from csf_ke.csf_ke.utils.tax_report import TaxReport
 
 
-class KenyaPurchaseTaxReport:
-	def __init__(self, filters=None):
-		self.filters = frappe._dict(filters or {})
-		self.registered_suppliers_total_purchases = 0
-		self.registered_suppliers_total_vat = 0
-		self.unregistered_suppliers_total_purchases = 0
-		self.unregistered_suppliers_total_vat = 0
+class KenyaPurchaseTaxReportFilters(TypedDict):
+	company: str | None
+	from_date: str | None
+	to_date: str | None
+	is_return: int | None
+	item_tax_template: str | None
+	taxes_and_charges_template: str | None
+
+
+def execute(filters: KenyaPurchaseTaxReportFilters | None = None):
+	report = KenyaPurchaseTaxReport(filters)
+	return report.run()
+
+
+class KenyaPurchaseTaxReport(TaxReport):
+	def __init__(self, filters: KenyaPurchaseTaxReportFilters | None = None):
+		super().__init__()
+		self.filters = filters or {}
+		self.company = self.filters.get("company")
+		self.from_date = self.filters.get("from_date")
+		self.to_date = self.filters.get("to_date")
+		self.item_tax_template = self.filters.get("item_tax_template")
+		self.taxes_and_charges_template = self.filters.get("taxes_and_charges_template")
 
 	def run(self):
 		columns = self.get_columns()
-		data = self.get_data()
-		report_summary = self.get_report_summary()
+		data = self.get_data("purchase")
 
-		return columns, data, None, None, report_summary
+		return columns, data, None, None, self.get_report_summary()
 
 	def get_columns(self):
-		columns = []
-
-		# Add accounting dimension column if filter is set
-		if self.filters.get("accounting_dimension"):
-			dimension_label = self.filters.get("accounting_dimension")
-			columns.append(
-				{
-					"label": _(dimension_label),
-					"fieldname": "accounting_dimension_value",
-					"fieldtype": "Link",
-					"options": dimension_label,
-					"width": 180,
-				}
-			)
-
-		columns += [
+		columns = [
 			{
-				"label": _("PIN of supplier"),
-				"fieldname": "pin_of_supplier",
+				"label": _("Supplier PIN"),
+				"fieldname": "tax_id",
 				"fieldtype": "Data",
-				"width": 160,
+				"width": 150,
 			},
 			{
-				"label": _("Name of supplier"),
-				"fieldname": "name_of_supplier",
+				"label": _("Supplier Name"),
+				"fieldname": "party_name",
 				"fieldtype": "Data",
-				"width": 240,
+				"width": 200,
+			},
+			{
+				"label": _("Invoice Number"),
+				"fieldname": "invoice_number",
+				"fieldtype": "Link",
+				"options": "Purchase Invoice",
+				"width": 200,
+			},
+			{
+				"label": _("Invoice Date"),
+				"fieldname": "invoice_date",
+				"fieldtype": "Date",
+				"width": 200,
 			},
 			{
 				"label": _("ETR Invoice Number"),
@@ -67,410 +73,80 @@ class KenyaPurchaseTaxReport:
 				"width": 200,
 			},
 			{
-				"label": _("Invoice Date"),
-				"fieldname": "invoice_date",
-				"fieldtype": "Date",
-				"width": 160,
-			},
-			{
-				"label": _("Invoice Number"),
-				"fieldname": "invoice_name",
-				"fieldtype": "Link",
-				"options": "Purchase Invoice",
-				"width": 200,
-			},
-			{
 				"label": _("Supplier Invoice No"),
-				"fieldname": "bill_no",
+				"fieldname": "supplier_invoice_no",
 				"fieldtype": "Data",
 				"width": 200,
 			},
 			{
 				"label": _("Supplier Invoice Date"),
-				"fieldname": "bill_date",
-				"fieldtype": "Data",
-				"width": 200,
-			},
-			{
-				"label": _("Taxable Value(Ksh)"),
-				"fieldname": "taxable_value",
-				"fieldtype": "Currency",
-				"width": 160,
-			},
-			{
-				"label": _("Amount of VAT(Ksh)"),
-				"fieldname": "amount_of_vat",
-				"fieldtype": "Currency",
-				"width": 160,
-			},
-			{
-				"label": _("Return CU Invoice Number"),
-				"fieldname": "return_cu_invoice_number",
-				"fieldtype": "Data",
-				"width": 200,
-			},
-			{
-				"label": _("Return CU Invoice Date"),
-				"fieldname": "return_cu_invoice_date",
+				"fieldname": "supplier_invoice_date",
 				"fieldtype": "Date",
-				"width": 160,
+				"width": 200,
+			},
+			{
+				"label": _("Taxable Amount"),
+				"fieldname": "taxable_amount",
+				"fieldtype": "Currency",
+				"options": "currency",
+				"width": 200,
+			},
+			{
+				"label": _("VAT Amount"),
+				"fieldname": "vat_amount",
+				"fieldtype": "Currency",
+				"options": "currency",
+				"width": 200,
+			},
+			{
+				"label": _("Currency"),
+				"fieldname": "currency",
+				"fieldtype": "Data",
+				"width": 200,
+				"hidden": 1,
 			},
 		]
 
-		if self.filters.is_return == "Is Return":
-			columns += [
+		if self.filters.get("is_return"):
+			columns.append(
 				{
 					"label": _("Return Against"),
 					"fieldname": "return_against",
-					"fieldtype": "Link",
-					"options": "Purchase Invoice",
+					"fieldtype": "Data",
 					"width": 200,
 				}
-			]
+			)
+
 		return columns
-
-	def get_purchase_invoices(self):
-		company = self.filters.company
-		from_date = self.filters.from_date
-		to_date = self.filters.to_date
-		is_return = self.filters.is_return
-
-		purchase_invoice_ = frappe.qb.DocType("Purchase Invoice")
-		supplier_ = frappe.qb.DocType("Supplier")
-
-		# Build select fields list
-		select_fields = [
-			supplier_.tax_id.as_("pin_of_supplier"),
-			purchase_invoice_.supplier_name.as_("name_of_supplier"),
-			purchase_invoice_.etr_invoice_number.as_("etr_invoice_number"),
-			purchase_invoice_.bill_date.as_("invoice_date"),
-			purchase_invoice_.name.as_("invoice_name"),
-			purchase_invoice_.bill_date.as_("bill_date"),
-			purchase_invoice_.bill_no.as_("bill_no"),
-			purchase_invoice_.base_grand_total.as_("invoice_total_purchases"),
-			purchase_invoice_.return_against.as_("return_against"),
-		]
-
-		# Add accounting dimension field if specified
-		accounting_dimension = self.filters.get("accounting_dimension")
-		if accounting_dimension:
-			dimension_field_map = {"Cost Center": "cost_center", "Project": "project"}
-			dimension_field = dimension_field_map.get(accounting_dimension)
-			if dimension_field:
-				select_fields.append(
-					getattr(purchase_invoice_, dimension_field).as_("accounting_dimension_value")
-				)
-
-		purchase_invoices_query = (
-			frappe.qb.from_(purchase_invoice_)
-			.inner_join(supplier_)
-			.on(purchase_invoice_.supplier == supplier_.name)
-			.select(*select_fields)
-			.where(purchase_invoice_.docstatus == 1)
-		)
-
-		if company:
-			purchase_invoices_query = purchase_invoices_query.where(purchase_invoice_.company == company)
-		if is_return == "Is Return":
-			purchase_invoices_query = purchase_invoices_query.where(purchase_invoice_.is_return == 1)
-		if is_return == "Normal Purchase Invoice":
-			purchase_invoices_query = purchase_invoices_query.where(purchase_invoice_.is_return == 0)
-		if from_date is not None:
-			purchase_invoices_query = purchase_invoices_query.where(
-				purchase_invoice_.posting_date >= from_date
-			)
-		if to_date:
-			purchase_invoices_query = purchase_invoices_query.where(purchase_invoice_.posting_date <= to_date)
-
-		purchase_invoices = purchase_invoices_query.run(as_dict=True)
-
-		for invoice in purchase_invoices:
-			if invoice.get("return_against"):
-				return_invoice_details = frappe.db.get_value(
-					"Purchase Invoice",
-					invoice["return_against"],
-					["etr_invoice_number", "bill_date"],
-					as_dict=True,
-				)
-				if return_invoice_details:
-					invoice["return_cu_invoice_number"] = return_invoice_details.get("etr_invoice_number")
-					invoice["return_cu_invoice_date"] = return_invoice_details.get("bill_date")
-
-		return purchase_invoices
-
-	def get_purchase_invoice_items(self, purchase_invoice_name, tax_template=None):
-		purchase_invoice_item_ = frappe.qb.DocType("Purchase Invoice Item")
-		purchase_invoice_items_query = (
-			frappe.qb.from_(purchase_invoice_item_)
-			.select(
-				purchase_invoice_item_.amount.as_("amount"),
-				purchase_invoice_item_.base_net_amount.as_("taxable_value"),
-				purchase_invoice_item_.item_tax_template.as_("item_tax_template"),
-			)
-			.where(purchase_invoice_item_.parent == purchase_invoice_name)
-		)
-
-		if tax_template:
-			purchase_invoice_items_query = purchase_invoice_items_query.where(
-				purchase_invoice_item_.item_tax_template == tax_template
-			)
-
-		items_or_services = purchase_invoice_items_query.run(as_dict=True)
-		return items_or_services
-
-	def get_data(self):
-		if self.filters.from_date > self.filters.to_date:
-			frappe.throw(_("To Date cannot be before From Date. {}").format(self.filters.to_date))
-
-		report_details = []
-
-		purchase_invoices = self.get_purchase_invoices()
-
-		for purchase_invoice in purchase_invoices:
-			items_or_services = self.get_purchase_invoice_items(
-				purchase_invoice.invoice_name, self.filters.tax_template
-			)
-
-			total_taxable_value = 0
-			total_vat = 0
-
-			for item_or_service in items_or_services:
-				tax_rate = frappe.db.get_value(
-					"Item Tax Template Detail",
-					{"parent": item_or_service["item_tax_template"]},
-					["tax_rate"],
-				)
-				item_or_service["amount_of_vat"] = (
-					0 if not tax_rate else item_or_service["taxable_value"] * (tax_rate / 100)
-				)
-
-				total_taxable_value += item_or_service["taxable_value"]
-				total_vat += item_or_service["amount_of_vat"]
-
-			purchase_invoice["taxable_value"] = total_taxable_value
-			purchase_invoice["amount_of_vat"] = total_vat
-
-			if total_taxable_value:
-				report_details.append(purchase_invoice)
-
-		for report_entry in report_details:
-			if report_entry["pin_of_supplier"]:
-				self.registered_suppliers_total_purchases += report_entry["taxable_value"]
-				self.registered_suppliers_total_vat += report_entry["amount_of_vat"]
-			else:
-				self.unregistered_suppliers_total_purchases += report_entry["taxable_value"]
-				self.unregistered_suppliers_total_vat += report_entry["amount_of_vat"]
-
-		if self.filters.get("accounting_dimension") and report_details:
-			report_details = self.group_by_dimension(report_details)
-
-		return report_details
-
-	def group_by_dimension(self, data):
-		"""Group data by accounting dimension and add group headers with totals"""
-		grouped_data = defaultdict(list)
-		for row in data:
-			dimension_value = row.get("accounting_dimension_value") or _("No Dimension")
-			grouped_data[dimension_value].append(row)
-
-		final_data = []
-		for dimension_value in sorted(grouped_data.keys()):
-			group_rows = grouped_data[dimension_value]
-
-			group_taxable_value = sum(row.get("taxable_value", 0) for row in group_rows)
-			group_amount_of_vat = sum(row.get("amount_of_vat", 0) for row in group_rows)
-
-			group_header = {
-				"accounting_dimension_value": dimension_value,
-				"taxable_value": group_taxable_value,
-				"amount_of_vat": group_amount_of_vat,
-				"is_group_header": True,
-			}
-			final_data.append(group_header)
-
-			for row in group_rows:
-				row["indent"] = 1
-				final_data.append(row)
-
-		return final_data
 
 	def get_report_summary(self):
 		return [
 			{
 				"value": self.registered_suppliers_total_purchases,
 				"indicator": "Green",
-				"label": _("Registered suppliers total purchases"),
+				"label": _("Registered Suppliers Total Purchases"),
 				"datatype": "Currency",
-				"currency": "KES",
+				"currency": self.currency,
 			},
 			{
 				"value": self.registered_suppliers_total_vat,
 				"indicator": "Green",
-				"label": _("Registered suppliers total VAT"),
+				"label": _("Registered Suppliers Total VAT"),
 				"datatype": "Currency",
-				"currency": "KES",
+				"currency": self.currency,
 			},
 			{
 				"value": self.unregistered_suppliers_total_purchases,
 				"indicator": "Green",
-				"label": _("Unregistered suppliers total purchases"),
+				"label": _("Unregistered Suppliers Total Purchases"),
 				"datatype": "Currency",
-				"currency": "KES",
+				"currency": self.currency,
 			},
 			{
 				"value": self.unregistered_suppliers_total_vat,
 				"indicator": "Green",
-				"label": _("Unregistered suppliers total VAT"),
+				"label": _("Unregistered Suppliers Total VAT"),
 				"datatype": "Currency",
-				"currency": "KES",
+				"currency": self.currency,
 			},
 		]
-
-
-def _normalize_companies(company):
-	if not company:
-		return frappe.get_all("Company", pluck="name")
-
-	if isinstance(company, str):
-		company = company.strip()
-		if not company:
-			return frappe.get_all("Company", pluck="name")
-
-		if company.startswith("["):
-			try:
-				parsed_companies = frappe.parse_json(company)
-			except Exception:
-				parsed_companies = None
-
-			if isinstance(parsed_companies, list):
-				return [item for item in parsed_companies if item]
-
-		if "," in company:
-			return [item.strip() for item in company.split(",") if item.strip()]
-
-		return [company]
-
-	if isinstance(company, (list, tuple, set)):
-		return [item for item in company if item]
-
-	return [company]
-
-
-def _get_tax_templates_from_report_data(company, from_date=None, to_date=None):
-	purchase_invoice_ = frappe.qb.DocType("Purchase Invoice")
-	purchase_invoice_item_ = frappe.qb.DocType("Purchase Invoice Item")
-
-	tax_templates_query = (
-		frappe.qb.from_(purchase_invoice_item_)
-		.inner_join(purchase_invoice_)
-		.on(purchase_invoice_item_.parent == purchase_invoice_.name)
-		.select(purchase_invoice_item_.item_tax_template)
-		.distinct()
-		.where(purchase_invoice_.docstatus == 1)
-		.where(purchase_invoice_.company == company)
-	)
-
-	if from_date:
-		tax_templates_query = tax_templates_query.where(purchase_invoice_.posting_date >= from_date)
-	if to_date:
-		tax_templates_query = tax_templates_query.where(purchase_invoice_.posting_date <= to_date)
-
-	tax_template_rows = tax_templates_query.run(as_dict=True)
-	return sorted({row.get("item_tax_template") for row in tax_template_rows if row.get("item_tax_template")})
-
-
-@frappe.whitelist()
-def download_custom_csv_format(company: str, from_date: str | None = None, to_date: str | None = None):
-	if not from_date:
-		frappe.throw(_("From Date is required"))
-	if not to_date:
-		frappe.throw(_("To Date is required"))
-
-	from_date_str = from_date.strftime("%y-%m-%d") if isinstance(from_date, datetime) else from_date
-	to_date_str = to_date.strftime("%y-%m-%d") if isinstance(to_date, datetime) else to_date
-
-	private_path = frappe.utils.get_site_path("private", "files")
-	os.makedirs(private_path, exist_ok=True)
-
-	companies = _normalize_companies(company)
-	if not companies:
-		frappe.throw(_("At least one company is required"))
-
-	csv_files = {}
-
-	timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-
-	for company_name in companies:
-		tax_templates = _get_tax_templates_from_report_data(company_name, from_date, to_date)
-		if not tax_templates:
-			continue
-
-		company_abbr = frappe.db.get_value("Company", company_name, "abbr") or ""
-
-		for template_name in tax_templates:
-			sanitized_template_name = re.sub(r"[^\w]+", "_", template_name).lower()
-
-			csv_file_name = f"purchase_{sanitized_template_name[:20]}_{company_abbr}_{from_date_str}_to_{to_date_str}_{timestamp}.csv".strip(
-				"_"
-			)
-
-			full_file_path = os.path.join(private_path, csv_file_name)
-			file_url = f"/private/files/{csv_file_name}"
-
-			purchase_invoices = KenyaPurchaseTaxReport(
-				{
-					"company": company_name,
-					"from_date": from_date,
-					"to_date": to_date,
-					"tax_template": template_name,
-				}
-			).get_data()
-
-			if not purchase_invoices:
-				continue
-
-			with open(full_file_path, "w", newline="") as csvfile:
-				writer = csv.writer(csvfile)
-
-				for invoice in purchase_invoices:
-					if invoice.get("pin_of_supplier"):
-						writer.writerow(
-							[
-								"Local",
-								invoice.get("pin_of_supplier", ""),
-								invoice.get("name_of_supplier", ""),
-								invoice.get("bill_date").strftime("%d/%m/%Y")
-								if invoice.get("bill_date")
-								else "",
-								f"|{(invoice.get('etr_invoice_number', ''))}",
-								invoice.get("bill_no", ""),
-								"",
-								invoice.get("taxable_value", ""),
-								"",
-								f"{'|' + invoice.get('return_cu_invoice_number', '') if invoice.return_against else ''}",
-								(
-									invoice.get("return_cu_invoice_date").strftime("%d/%m/%Y")
-									if invoice.return_against and invoice.get("return_cu_invoice_date")
-									else ""
-								),
-							]
-						)
-
-			file_record = frappe.get_doc(
-				{
-					"doctype": "File",
-					"file_name": csv_file_name,
-					"file_url": file_url,
-					"attached_to_name": company_name,
-					"attached_to_doctype": "Purchase Invoice",
-					"file_size": os.path.getsize(full_file_path),
-					"is_private": 1,
-					"file_type": "CSV",
-				}
-			)
-			file_record.insert()
-
-			display_key = f"{company_name} - {template_name}" if len(companies) > 1 else template_name
-			csv_files[display_key] = file_url
-
-	return csv_files

--- a/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.py
+++ b/csf_ke/csf_ke/report/kenya_purchase_tax_report/kenya_purchase_tax_report.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2022, Navari Limited and contributors
 # For license information, please see license.txt
 
-
+import csv
+import os
+import re
+from datetime import datetime
 from typing import TypedDict
 
+import frappe
 from frappe import _
 
 from csf_ke.csf_ke.utils.tax_report import TaxReport
@@ -16,6 +20,7 @@ class KenyaPurchaseTaxReportFilters(TypedDict):
 	is_return: int | None
 	item_tax_template: str | None
 	taxes_and_charges_template: str | None
+	accounting_dimension: str | None
 
 
 def execute(filters: KenyaPurchaseTaxReportFilters | None = None):
@@ -105,16 +110,38 @@ class KenyaPurchaseTaxReport(TaxReport):
 				"width": 200,
 				"hidden": 1,
 			},
+			{
+				"label": _("Original CU Invoice Number"),
+				"fieldname": "original_cu_invoice_number",
+				"fieldtype": "Data",
+				"width": 200,
+			},
+			{
+				"label": _("Original CU Invoice Date"),
+				"fieldname": "original_cu_invoice_date",
+				"fieldtype": "Date",
+				"width": 200,
+			},
+			{
+				"label": _("Return Against"),
+				"fieldname": "return_against",
+				"fieldtype": "Link",
+				"options": "Purchase Invoice",
+				"width": 200,
+			},
 		]
 
-		if self.filters.get("is_return"):
-			columns.append(
+		if self.filters.get("accounting_dimension"):
+			dimension = self.filters.get("accounting_dimension")
+			columns.insert(
+				0,
 				{
-					"label": _("Return Against"),
-					"fieldname": "return_against",
-					"fieldtype": "Data",
+					"label": _(dimension),
+					"fieldname": "accounting_dimension_value",
+					"fieldtype": "Link",
+					"options": dimension,
 					"width": 200,
-				}
+				},
 			)
 
 		return columns
@@ -150,3 +177,155 @@ class KenyaPurchaseTaxReport(TaxReport):
 				"currency": self.currency,
 			},
 		]
+
+
+def _normalize_companies(company):
+	if not company:
+		return frappe.get_all("Company", pluck="name")
+
+	if isinstance(company, str):
+		company = company.strip()
+		if not company:
+			return frappe.get_all("Company", pluck="name")
+
+		if company.startswith("["):
+			try:
+				parsed_companies = frappe.parse_json(company)
+			except Exception:
+				parsed_companies = None
+
+			if isinstance(parsed_companies, list):
+				return [item for item in parsed_companies if item]
+
+		if "," in company:
+			return [item.strip() for item in company.split(",") if item.strip()]
+
+		return [company]
+
+	if isinstance(company, (list, tuple, set)):
+		return [item for item in company if item]
+
+	return [company]
+
+
+def _get_tax_templates_from_report_data(company, from_date=None, to_date=None):
+	purchase_invoice_ = frappe.qb.DocType("Purchase Invoice")
+	purchase_invoice_item_ = frappe.qb.DocType("Purchase Invoice Item")
+
+	tax_templates_query = (
+		frappe.qb.from_(purchase_invoice_item_)
+		.inner_join(purchase_invoice_)
+		.on(purchase_invoice_item_.parent == purchase_invoice_.name)
+		.select(purchase_invoice_item_.item_tax_template)
+		.distinct()
+		.where(purchase_invoice_.docstatus == 1)
+		.where(purchase_invoice_.company == company)
+	)
+
+	if from_date:
+		tax_templates_query = tax_templates_query.where(purchase_invoice_.posting_date >= from_date)
+	if to_date:
+		tax_templates_query = tax_templates_query.where(purchase_invoice_.posting_date <= to_date)
+
+	tax_template_rows = tax_templates_query.run(as_dict=True)
+	return sorted({row.get("item_tax_template") for row in tax_template_rows if row.get("item_tax_template")})
+
+
+@frappe.whitelist()
+def download_custom_csv_format(company: str, from_date: str | None = None, to_date: str | None = None):
+	if not from_date:
+		frappe.throw(_("From Date is required"))
+	if not to_date:
+		frappe.throw(_("To Date is required"))
+
+	from_date_str = from_date.strftime("%y-%m-%d") if isinstance(from_date, datetime) else from_date
+	to_date_str = to_date.strftime("%y-%m-%d") if isinstance(to_date, datetime) else to_date
+
+	private_path = frappe.utils.get_site_path("private", "files")
+	os.makedirs(private_path, exist_ok=True)
+
+	companies = _normalize_companies(company)
+	if not companies:
+		frappe.throw(_("At least one company is required"))
+
+	csv_files = {}
+
+	timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+	for company_name in companies:
+		tax_templates = _get_tax_templates_from_report_data(company_name, from_date, to_date)
+		if not tax_templates:
+			continue
+
+		company_abbr = frappe.db.get_value("Company", company_name, "abbr") or ""
+
+		for template_name in tax_templates:
+			sanitized_template_name = re.sub(r"[^\w]+", "_", template_name).lower()
+
+			csv_file_name = f"purchase_{sanitized_template_name[:20]}_{company_abbr}_{from_date_str}_to_{to_date_str}_{timestamp}.csv".strip(
+				"_"
+			)
+
+			full_file_path = os.path.join(private_path, csv_file_name)
+			file_url = f"/private/files/{csv_file_name}"
+
+			purchase_invoices = KenyaPurchaseTaxReport(
+				{
+					"company": company_name,
+					"from_date": from_date,
+					"to_date": to_date,
+					"item_tax_template": template_name,
+				}
+			).get_data("purchase")
+
+			if not purchase_invoices:
+				continue
+
+			with open(full_file_path, "w", newline="") as csvfile:
+				writer = csv.writer(csvfile)
+
+				for invoice in purchase_invoices:
+					if invoice.get("tax_id"):
+						writer.writerow(
+							[
+								"Local",
+								invoice.get("tax_id", ""),
+								invoice.get("party_name", ""),
+								(
+									invoice.get("invoice_date").strftime("%d/%m/%Y")
+									if invoice.get("invoice_date")
+									else ""
+								),
+								f"|{(invoice.get('etr_invoice_number', ''))}",
+								invoice.get("invoice_number", ""),
+								"",
+								invoice.get("taxable_amount", ""),
+								"",
+								f"{'|' + invoice.get('original_cu_invoice_number', '') if invoice.get('return_against') else ''}",
+								(
+									invoice.get("original_cu_invoice_date").strftime("%d/%m/%Y")
+									if invoice.get("return_against")
+									and invoice.get("original_cu_invoice_date")
+									else ""
+								),
+							]
+						)
+
+			file_record = frappe.get_doc(
+				{
+					"doctype": "File",
+					"file_name": csv_file_name,
+					"file_url": file_url,
+					"attached_to_name": company_name,
+					"attached_to_doctype": "Purchase Invoice",
+					"file_size": os.path.getsize(full_file_path),
+					"is_private": 1,
+					"file_type": "CSV",
+				}
+			)
+			file_record.insert()
+
+			display_key = f"{company_name} - {template_name}" if len(companies) > 1 else template_name
+			csv_files[display_key] = file_url
+
+	return csv_files

--- a/csf_ke/csf_ke/report/sales_person_wise_transaction_summary_enhanced/sales_person_wise_transaction_summary_enhanced.py
+++ b/csf_ke/csf_ke/report/sales_person_wise_transaction_summary_enhanced/sales_person_wise_transaction_summary_enhanced.py
@@ -7,12 +7,19 @@ from collections import OrderedDict
 import frappe
 from erpnext import get_company_currency
 from frappe import _, msgprint, qb
-from frappe.query_builder import Criterion
+from frappe.query_builder import Case, Criterion
+from frappe.query_builder.functions import Month, Quarter, Year
+from pypika.terms import Function, ValueWrapper
+
+ALLOWED_DOCTYPES = ["Sales Order", "Sales Invoice", "Delivery Note"]
+ALLOWED_DURATIONS = ["Monthly", "Quarterly", "Yearly", "Weekly"]
 
 
 def execute(filters=None):
 	if not filters:
 		filters = {}
+
+	validate_filters(filters)
 
 	columns = get_columns(filters)
 	entries = get_entries(filters)
@@ -24,8 +31,10 @@ def execute(filters=None):
 	grouped = OrderedDict()
 
 	for d in entries:
-		row = frappe._dict()
-		grouped.setdefault(
+		if not (d.stock_qty > 0 or filters.get("show_return_entries", 0)):
+			continue
+
+		group = grouped.setdefault(
 			d.duration,
 			[
 				frappe._dict(
@@ -38,35 +47,45 @@ def execute(filters=None):
 					contribution_amt=None,
 				)
 			],
-		).append(
-			row.update(
-				{
-					"indent": 1,
-				}
-			)
 		)
 
-		if d.stock_qty > 0 or filters.get("show_return_entries", 0):
-			row[frappe.scrub(filters["doc_type"])] = d.name
-			row.customer = d.customer
-			row.territory = d.territory
-			row.warehouse = d.warehouse
-			row.posting_date = d.posting_date
-			row.item_code = d.item_code
-			row.item_group = item_details.get(d.item_code, {}).get("item_group")
-			row.brand = item_details.get(d.item_code, {}).get("brand")
-			row.qty = d.stock_qty
-			row.amount = d.base_net_amount
-			row.sales_person = d.sales_person
-			row.contribution = d.allocated_percentage
-			row.contribution_qty = d.stock_qty * d.allocated_percentage / 100
-			row.contribution_amt = d.contribution_amt
-			row.currency = company_currency
+		row = frappe._dict(
+			{
+				"indent": 1,
+				frappe.scrub(filters["doc_type"]): d.name,
+				"customer": d.customer,
+				"territory": d.territory,
+				"warehouse": d.warehouse,
+				"posting_date": d.posting_date,
+				"item_code": d.item_code,
+				"item_group": item_details.get(d.item_code, {}).get("item_group"),
+				"brand": item_details.get(d.item_code, {}).get("brand"),
+				"qty": d.stock_qty,
+				"amount": d.base_net_amount,
+				"sales_person": d.sales_person,
+				"contribution": d.allocated_percentage,
+				"contribution_qty": d.stock_qty * d.allocated_percentage / 100,
+				"contribution_amt": d.contribution_amt,
+				"currency": company_currency,
+			}
+		)
+		group.append(row)
 
 	for group in grouped.values():
 		data.extend(group)
 
 	return columns, data
+
+
+def validate_filters(filters):
+	if not filters.get("doc_type"):
+		msgprint(_("Please select the document type first"), raise_exception=1)
+
+	if filters.get("doc_type") not in ALLOWED_DOCTYPES:
+		frappe.throw(_("{0}, {1} or {2} are the only allowed options.").format(*ALLOWED_DOCTYPES))
+
+	if filters.get("duration") and filters.get("duration") not in ALLOWED_DURATIONS:
+		frappe.throw(_("Duration must be one of {0}.").format(", ".join(ALLOWED_DURATIONS)))
 
 
 def get_columns(filters):
@@ -185,115 +204,100 @@ def get_columns(filters):
 	return columns
 
 
-def get_duration_clause(filters):
-	duration_clause = None
-	if filters["duration"] == "Monthly":
-		duration_clause = "MONTH(dt.{}) as duration"
-
-	elif filters["duration"] == "Quarterly":
-		duration_clause = "QUARTER(dt.{}) as duration"
-
-	elif filters["duration"] == "Yearly":
-		duration_clause = "YEAR(dt.{}) as duration"
-
-	elif filters["duration"] == "Weekly":
-		duration_clause = "WEEK(dt.{}) as duration"
-
-	if duration_clause:
-		if filters["doc_type"] in ("Sales Invoice", "Delivery Note"):
-			duration_clause = duration_clause.format("posting_date")
-
-		else:
-			duration_clause = duration_clause.format("transaction_date")
-
-	return duration_clause
+def get_duration_field(dt, date_field, duration):
+	field = dt[date_field]
+	if duration == "Monthly":
+		return Month(field).as_("duration")
+	if duration == "Quarterly":
+		return Quarter(field).as_("duration")
+	if duration == "Yearly":
+		return Year(field).as_("duration")
+	if duration == "Weekly":
+		return Function("WEEK", field).as_("duration")
+	return ValueWrapper(None).as_("duration")
 
 
 def get_entries(filters):
-	date_field = (filters["doc_type"] == "Sales Order" and "transaction_date") or "posting_date"
+	doc_type = filters["doc_type"]
+	date_field = "transaction_date" if doc_type == "Sales Order" else "posting_date"
+	qty_field = "delivered_qty" if doc_type == "Sales Order" else "qty"
 
-	if filters["doc_type"] == "Sales Order":
-		qty_field = "delivered_qty"
-	else:
-		qty_field = "qty"
+	dt = frappe.qb.DocType(doc_type)
+	dt_item = frappe.qb.DocType(f"{doc_type} Item")
+	st = frappe.qb.DocType("Sales Team")
 
-	conditions, values = get_conditions(filters, date_field)
-	duration_clause = get_duration_clause(filters)
+	calc_qty = dt_item[qty_field] * dt_item.conversion_factor
+	calc_net_amount = dt_item.base_net_rate * calc_qty
 
-	entries = frappe.db.sql(
-		"""
-        SELECT
-            dt.name, dt.customer, dt.territory, dt.{} as posting_date, dt_item.item_code,
-            st.sales_person, st.allocated_percentage, dt_item.warehouse,
-        CASE
-            WHEN dt.status = "Closed" THEN dt_item.{} * dt_item.conversion_factor
-            ELSE dt_item.stock_qty
-        END as stock_qty,
-        CASE
-            WHEN dt.status = "Closed" THEN (dt_item.base_net_rate * dt_item.{} * dt_item.conversion_factor)
-            ELSE dt_item.base_net_amount
-        END as base_net_amount,
-        CASE
-            WHEN dt.status = "Closed" THEN ((dt_item.base_net_rate * dt_item.{} * dt_item.conversion_factor) * st.allocated_percentage/100)
-            ELSE dt_item.base_net_amount * st.allocated_percentage/100
-        END as contribution_amt, {}
-        FROM
-            `tab{}` dt, `tab{} Item` dt_item, `tabSales Team` st
-        WHERE
-            st.parent = dt.name and dt.name = dt_item.parent and st.parenttype = {}
-            and dt.docstatus = 1 {}
-        ORDER BY st.sales_person, dt.name desc
-        """.format(
-			date_field,
-			qty_field,
-			qty_field,
-			qty_field,
-			duration_clause,
-			filters["doc_type"],
-			filters["doc_type"],
-			"%s",
-			conditions,
-		),
-		tuple([filters["doc_type"], *values]),
-		as_dict=1,
+	stock_qty_case = Case().when(dt.status == "Closed", calc_qty).else_(dt_item.stock_qty).as_("stock_qty")
+	base_net_amount_case = (
+		Case()
+		.when(dt.status == "Closed", calc_net_amount)
+		.else_(dt_item.base_net_amount)
+		.as_("base_net_amount")
 	)
+	contribution_amt_case = (
+		Case()
+		.when(dt.status == "Closed", (calc_net_amount * st.allocated_percentage / 100))
+		.else_(dt_item.base_net_amount * st.allocated_percentage / 100)
+		.as_("contribution_amt")
+	)
+	duration_field = get_duration_field(dt, date_field, filters.get("duration"))
 
-	return entries
-
-
-def get_conditions(filters, date_field):
-	conditions = [""]
-	values = []
-
+	doc_filters = {"docstatus": 1}
 	for field in ["company", "customer", "territory"]:
 		if filters.get(field):
-			conditions.append(f"dt.{field}=%s")
-			values.append(filters[field])
+			doc_filters[field] = filters.get(field)
+
+	if filters.get("from_date") and filters.get("to_date"):
+		doc_filters[date_field] = [
+			"between",
+			[filters.get("from_date"), filters.get("to_date")],
+		]
+	elif filters.get("from_date"):
+		doc_filters[date_field] = [">=", filters.get("from_date")]
+	elif filters.get("to_date"):
+		doc_filters[date_field] = ["<=", filters.get("to_date")]
+
+	query = (
+		frappe.get_query(dt, filters=doc_filters, ignore_permissions=False)
+		.join(dt_item)
+		.on(dt.name == dt_item.parent)
+		.join(st)
+		.on(dt.name == st.parent)
+		.select(
+			dt.name,
+			dt.customer,
+			dt.territory,
+			dt[date_field].as_("posting_date"),
+			dt_item.item_code,
+			st.sales_person,
+			st.allocated_percentage,
+			dt_item.warehouse,
+			stock_qty_case,
+			base_net_amount_case,
+			contribution_amt_case,
+			duration_field,
+		)
+		.where(st.parenttype == doc_type)
+	)
 
 	if filters.get("sales_person"):
-		lft, rgt = frappe.get_value("Sales Person", filters.get("sales_person"), ["lft", "rgt"])
-		conditions.append(
-			f"exists(select name from `tabSales Person` where lft >= {lft} and rgt <= {rgt} and name=st.sales_person)"
+		lft, rgt = frappe.db.get_value("Sales Person", filters.get("sales_person"), ["lft", "rgt"])
+		sp = frappe.qb.DocType("Sales Person")
+		query = query.where(
+			st.sales_person.isin(frappe.qb.from_(sp).select(sp.name).where((sp.lft >= lft) & (sp.rgt <= rgt)))
 		)
 
-	if filters.get("from_date"):
-		conditions.append(f"dt.{date_field}>=%s")
-		values.append(filters["from_date"])
+	if filters.get("item_group") or filters.get("brand"):
+		items = get_items(filters)
+		if not items:
+			return []
+		query = query.where(dt_item.item_code.isin([d[0] for d in items]))
 
-	if filters.get("to_date"):
-		conditions.append(f"dt.{date_field}<=%s")
-		values.append(filters["to_date"])
+	query = query.orderby(st.sales_person).orderby(dt.name, order=frappe.qb.desc)
 
-	items = get_items(filters)
-	if items:
-		placeholders = ", ".join(["%s"] * len(items))
-		conditions.append(f"dt_item.item_code in ({placeholders})")
-		values += items
-	else:
-		# return empty result, if no items are fetched after filtering on 'item group' and 'brand'
-		conditions.append("dt_item.item_code = Null")
-
-	return " and ".join(conditions), values
+	return query.run(as_dict=True)
 
 
 def get_items(filters):

--- a/csf_ke/csf_ke/report/sales_person_wise_transaction_summary_enhanced/sales_person_wise_transaction_summary_enhanced.py
+++ b/csf_ke/csf_ke/report/sales_person_wise_transaction_summary_enhanced/sales_person_wise_transaction_summary_enhanced.py
@@ -11,200 +11,218 @@ from frappe.query_builder import Criterion
 
 
 def execute(filters=None):
-	if not filters:
-		filters = {}
+    if not filters:
+        filters = {}
 
-	columns = get_columns(filters)
-	entries = get_entries(filters)
-	item_details = get_item_details()
-	data = []
+    columns = get_columns(filters)
+    entries = get_entries(filters)
+    item_details = get_item_details()
+    data = []
 
-	company_currency = get_company_currency(filters.get("company"))
+    company_currency = get_company_currency(filters.get("company"))
 
-	grouped = OrderedDict()
+    grouped = OrderedDict()
 
-	for d in entries:
-		row = frappe._dict()
-		grouped.setdefault(d.duration, [frappe._dict(duration=d.duration, indent=0)]).append(
-			row.update({"indent": 1})
-		)
+    for d in entries:
+        row = frappe._dict()
+        grouped.setdefault(
+            d.duration,
+            [
+                frappe._dict(
+                    duration=d.duration,
+                    indent=0,
+                    qty=None,
+                    amount=None,
+                    contribution=None,
+                    contribution_qty=None,
+                    contribution_amt=None,
+                )
+            ],
+        ).append(
+            row.update(
+                {
+                    "indent": 1,
+                }
+            )
+        )
 
-		if d.stock_qty > 0 or filters.get("show_return_entries", 0):
-			row[frappe.scrub(filters["doc_type"])] = d.name
-			row.customer = d.customer
-			row.territory = d.territory
-			row.warehouse = d.warehouse
-			row.posting_date = d.posting_date
-			row.item_code = d.item_code
-			row.item_group = item_details.get(d.item_code, {}).get("item_group")
-			row.brand = item_details.get(d.item_code, {}).get("item_group")
-			row.stock_qty = d.stock_qty
-			row.base_net_amount = d.base_net_amount
-			row.sales_person = d.sales_person
-			row.allocated_percentage = d.allocated_percentage
-			row.contribution = d.stock_qty * d.allocated_percentage / 100
-			row.contribution_amt = d.contribution_amt
-			row.company_currency = d.company_currency
-			row.currency = company_currency
+        if d.stock_qty > 0 or filters.get("show_return_entries", 0):
+            row[frappe.scrub(filters["doc_type"])] = d.name
+            row.customer = d.customer
+            row.territory = d.territory
+            row.warehouse = d.warehouse
+            row.posting_date = d.posting_date
+            row.item_code = d.item_code
+            row.item_group = item_details.get(d.item_code, {}).get("item_group")
+            row.brand = item_details.get(d.item_code, {}).get("brand")
+            row.qty = d.stock_qty
+            row.amount = d.base_net_amount
+            row.sales_person = d.sales_person
+            row.contribution = d.allocated_percentage
+            row.contribution_qty = d.stock_qty * d.allocated_percentage / 100
+            row.contribution_amt = d.contribution_amt
+            row.currency = company_currency
 
-	for group in grouped.values():
-		data.extend(group)
+    for group in grouped.values():
+        data.extend(group)
 
-	return columns, data
+    return columns, data
 
 
 def get_columns(filters):
-	if not filters.get("doc_type"):
-		msgprint(_("Please select the document type first"), raise_exception=True)
+    if not filters.get("doc_type"):
+        msgprint(_("Please select the document type first"), raise_exception=True)
 
-	columns = [
-		{
-			"label": _(filters["duration"][:-2]),
-			"fieldname": "duration",
-			"fieldtype": "Data",
-		},
-		{
-			"label": _(filters["doc_type"]),
-			"options": filters["doc_type"],
-			"fieldname": frappe.scrub(filters["doc_type"]),
-			"fieldtype": "Link",
-			"width": 140,
-		},
-		{
-			"label": _("Customer"),
-			"options": "Customer",
-			"fieldname": "customer",
-			"fieldtype": "Link",
-			"width": 140,
-		},
-		{
-			"label": _("Territory"),
-			"options": "Territory",
-			"fieldname": "territory",
-			"fieldtype": "Link",
-			"width": 140,
-		},
-		{
-			"label": _("Warehouse"),
-			"options": "Warehouse",
-			"fieldname": "warehouse",
-			"fieldtype": "Link",
-			"width": 140,
-		},
-		{
-			"label": _("Posting Date"),
-			"fieldname": "posting_date",
-			"fieldtype": "Date",
-			"width": 140,
-		},
-		{
-			"label": _("Item Code"),
-			"options": "Item",
-			"fieldname": "item_code",
-			"fieldtype": "Link",
-			"width": 140,
-		},
-		{
-			"label": _("Item Group"),
-			"options": "Item Group",
-			"fieldname": "item_group",
-			"fieldtype": "Link",
-			"width": 140,
-		},
-		{
-			"label": _("Brand"),
-			"options": "Brand",
-			"fieldname": "brand",
-			"fieldtype": "Link",
-			"width": 140,
-		},
-		{
-			"label": _("SO Total Qty"),
-			"fieldname": "qty",
-			"fieldtype": "Float",
-			"width": 140,
-		},
-		{
-			"label": _("Amount"),
-			"options": "currency",
-			"fieldname": "amount",
-			"fieldtype": "Currency",
-			"width": 140,
-		},
-		{
-			"label": _("Sales Person"),
-			"options": "Sales Person",
-			"fieldname": "sales_person",
-			"fieldtype": "Link",
-			"width": 140,
-		},
-		{
-			"label": _("Contribution %"),
-			"fieldname": "contribution",
-			"fieldtype": "Float",
-			"width": 140,
-		},
-		{
-			"label": _("Contribution Qty"),
-			"fieldname": "contribution_qty",
-			"fieldtype": "Float",
-			"width": 140,
-		},
-		{
-			"label": _("Contribution Amount"),
-			"options": "currency",
-			"fieldname": "contribution_amt",
-			"fieldtype": "Currency",
-			"width": 140,
-		},
-		{
-			"label": _("Currency"),
-			"options": "Currency",
-			"fieldname": "currency",
-			"fieldtype": "Link",
-			"hidden": 1,
-		},
-	]
+    columns = [
+        {
+            "label": _(filters["duration"][:-2]),
+            "fieldname": "duration",
+            "fieldtype": "Data",
+        },
+        {
+            "label": _(filters["doc_type"]),
+            "options": filters["doc_type"],
+            "fieldname": frappe.scrub(filters["doc_type"]),
+            "fieldtype": "Link",
+            "width": 140,
+        },
+        {
+            "label": _("Customer"),
+            "options": "Customer",
+            "fieldname": "customer",
+            "fieldtype": "Link",
+            "width": 140,
+        },
+        {
+            "label": _("Territory"),
+            "options": "Territory",
+            "fieldname": "territory",
+            "fieldtype": "Link",
+            "width": 140,
+        },
+        {
+            "label": _("Warehouse"),
+            "options": "Warehouse",
+            "fieldname": "warehouse",
+            "fieldtype": "Link",
+            "width": 140,
+        },
+        {
+            "label": _("Posting Date"),
+            "fieldname": "posting_date",
+            "fieldtype": "Date",
+            "width": 140,
+        },
+        {
+            "label": _("Item Code"),
+            "options": "Item",
+            "fieldname": "item_code",
+            "fieldtype": "Link",
+            "width": 140,
+        },
+        {
+            "label": _("Item Group"),
+            "options": "Item Group",
+            "fieldname": "item_group",
+            "fieldtype": "Link",
+            "width": 140,
+        },
+        {
+            "label": _("Brand"),
+            "options": "Brand",
+            "fieldname": "brand",
+            "fieldtype": "Link",
+            "width": 140,
+        },
+        {
+            "label": _("SO Total Qty"),
+            "fieldname": "qty",
+            "fieldtype": "Float",
+            "width": 140,
+        },
+        {
+            "label": _("Amount"),
+            "options": "currency",
+            "fieldname": "amount",
+            "fieldtype": "Currency",
+            "width": 140,
+        },
+        {
+            "label": _("Sales Person"),
+            "options": "Sales Person",
+            "fieldname": "sales_person",
+            "fieldtype": "Link",
+            "width": 140,
+        },
+        {
+            "label": _("Contribution %"),
+            "fieldname": "contribution",
+            "fieldtype": "Float",
+            "width": 140,
+        },
+        {
+            "label": _("Contribution Qty"),
+            "fieldname": "contribution_qty",
+            "fieldtype": "Float",
+            "width": 140,
+        },
+        {
+            "label": _("Contribution Amount"),
+            "options": "currency",
+            "fieldname": "contribution_amt",
+            "fieldtype": "Currency",
+            "width": 140,
+        },
+        {
+            "label": _("Currency"),
+            "options": "Currency",
+            "fieldname": "currency",
+            "fieldtype": "Link",
+            "hidden": 1,
+        },
+    ]
 
-	return columns
+    return columns
 
 
 def get_duration_clause(filters):
-	duration_clause = None
-	if filters["duration"] == "Monthly":
-		duration_clause = "MONTH(dt.{}) as duration"
+    duration_clause = None
+    if filters["duration"] == "Monthly":
+        duration_clause = "MONTH(dt.{}) as duration"
 
-	elif filters["duration"] == "Quarterly":
-		duration_clause = "QUARTER(dt.{}) as duration"
+    elif filters["duration"] == "Quarterly":
+        duration_clause = "QUARTER(dt.{}) as duration"
 
-	elif filters["duration"] == "Yearly":
-		duration_clause = "YEAR(dt.{}) as duration"
+    elif filters["duration"] == "Yearly":
+        duration_clause = "YEAR(dt.{}) as duration"
 
-	elif filters["duration"] == "Weekly":
-		duration_clause = "WEEK(dt.{}) as duration"
+    elif filters["duration"] == "Weekly":
+        duration_clause = "WEEK(dt.{}) as duration"
 
-	if duration_clause:
-		if filters["doc_type"] in ("Sales Invoice", "Delivery Note"):
-			duration_clause = duration_clause.format("posting_date")
+    if duration_clause:
+        if filters["doc_type"] in ("Sales Invoice", "Delivery Note"):
+            duration_clause = duration_clause.format("posting_date")
 
-		else:
-			duration_clause = duration_clause.format("transaction_date")
+        else:
+            duration_clause = duration_clause.format("transaction_date")
 
-	return duration_clause
+    return duration_clause
 
 
 def get_entries(filters):
-	date_field = (filters["doc_type"] == "Sales Order" and "transaction_date") or "posting_date"
-	if filters["doc_type"] == "Sales Order":
-		qty_field = "delivered_qty"
-	else:
-		qty_field = "qty"
+    date_field = (
+        filters["doc_type"] == "Sales Order" and "transaction_date"
+    ) or "posting_date"
+    if filters["doc_type"] == "Sales Order":
+        qty_field = "delivered_qty"
+    else:
+        qty_field = "qty"
 
-	conditions, values = get_conditions(filters, date_field)
-	duration_clause = get_duration_clause(filters)
+    conditions, values = get_conditions(filters, date_field)
+    duration_clause = get_duration_clause(filters)
 
-	entries = frappe.db.sql(
-		"""
+    entries = frappe.db.sql(
+        """
         SELECT
             dt.name, dt.customer, dt.territory, dt.{} as posting_date, dt_item.item_code,
             st.sales_person, st.allocated_percentage, dt_item.warehouse,
@@ -219,7 +237,7 @@ def get_entries(filters):
         CASE
             WHEN dt.status = "Closed" THEN ((dt_item.base_net_rate * dt_item.{} * dt_item.conversion_factor) * st.allocated_percentage/100)
             ELSE dt_item.base_net_amount * st.allocated_percentage/100
-        END as contriQUARTERution_amt, {}
+        END as contribution_amt, {}
         FROM
             `tab{}` dt, `tab{} Item` dt_item, `tabSales Team` st
         WHERE
@@ -227,87 +245,136 @@ def get_entries(filters):
             and dt.docstatus = 1 {}
         ORDER BY st.sales_person, dt.name desc
         """.format(
-			date_field,
-			qty_field,
-			qty_field,
-			qty_field,
-			duration_clause,
-			filters["doc_type"],
-			filters["doc_type"],
-			"%s",
-			conditions,
-		),
-		tuple([filters["doc_type"], *values]),
-		as_dict=1,
-	)
+            date_field,
+            qty_field,
+            qty_field,
+            qty_field,
+            duration_clause,
+            filters["doc_type"],
+            filters["doc_type"],
+            "%s",
+            conditions,
+        ),
+        tuple([filters["doc_type"], *values]),
+        as_dict=1,
+    )
 
-	return entries
+    return entries
 
 
 def get_conditions(filters, date_field):
-	conditions = [""]
-	values = []
+    conditions = [""]
+    values = []
 
-	for field in ["company", "customer", "territory"]:
-		if filters.get(field):
-			conditions.append(f"dt.{field}=%s")
-			values.append(filters[field])
+    for field in ["company", "customer", "territory"]:
+        if filters.get(field):
+            conditions.append(f"dt.{field}=%s")
+            values.append(filters[field])
 
-	if filters.get("sales_person"):
-		lft, rgt = frappe.get_value("Sales Person", filters.get("sales_person"), ["lft", "rgt"])
-		conditions.append(
-			f"exists(select name from `tabSales Person` where lft >= {lft} and rgt <= {rgt} and name=st.sales_person)"
-		)
+    if filters.get("sales_person"):
+        lft, rgt = frappe.get_value(
+            "Sales Person", filters.get("sales_person"), ["lft", "rgt"]
+        )
+        conditions.append(
+            f"exists(select name from `tabSales Person` where lft >= {lft} and rgt <= {rgt} and name=st.sales_person)"
+        )
 
-	if filters.get("from_date"):
-		conditions.append(f"dt.{date_field}>=%s")
-		values.append(filters["from_date"])
+    if filters.get("from_date"):
+        conditions.append(f"dt.{date_field}>=%s")
+        values.append(filters["from_date"])
 
-	if filters.get("to_date"):
-		conditions.append(f"dt.{date_field}<=%s")
-		values.append(filters["to_date"])
+    if filters.get("to_date"):
+        conditions.append(f"dt.{date_field}<=%s")
+        values.append(filters["to_date"])
 
-	items = get_items(filters)
-	if items:
-		placeholders = ", ".join(["%s"] * len(items))
-		conditions.append(f"dt_item.item_code in ({placeholders})")
-		values += items
-	else:
-		# return empty result, if no items are fetched after filtering on 'item group' and 'brand'
-		conditions.append("dt_item.item_code = Null")
+    items = get_items(filters)
+    if items:
+        placeholders = ", ".join(["%s"] * len(items))
+        conditions.append(f"dt_item.item_code in ({placeholders})")
+        values += items
+    else:
+        # return empty result, if no items are fetched after filtering on 'item group' and 'brand'
+        conditions.append("dt_item.item_code = Null")
 
-	return " and ".join(conditions), values
+    return " and ".join(conditions), values
 
 
 def get_items(filters):
-	item = qb.DocType("Item")
+    item = qb.DocType("Item")
 
-	item_query_conditions = []
-	if filters.get("item_group"):
-		# Handle 'Parent' nodes as well.
-		item_group = qb.DocType("Item Group")
-		lft, rgt = frappe.db.get_all(
-			"Item Group",
-			filters={"name": filters.get("item_group")},
-			fields=["lft", "rgt"],
-			as_list=True,
-		)[0]
-		item_group_query = (
-			qb.from_(item_group)
-			.select(item_group.name)
-			.where((item_group.lft >= lft) & (item_group.rgt <= rgt))
-		)
-		item_query_conditions.append(item.item_group.isin(item_group_query))
-	if filters.get("brand"):
-		item_query_conditions.append(item.brand == filters.get("brand"))
+    item_query_conditions = []
+    if filters.get("item_group"):
+        # Handle 'Parent' nodes as well.
+        item_group = qb.DocType("Item Group")
+        lft, rgt = frappe.db.get_all(
+            "Item Group",
+            filters={"name": filters.get("item_group")},
+            fields=["lft", "rgt"],
+            as_list=True,
+        )[0]
+        item_group_query = (
+            qb.from_(item_group)
+            .select(item_group.name)
+            .where((item_group.lft >= lft) & (item_group.rgt <= rgt))
+        )
+        item_query_conditions.append(item.item_group.isin(item_group_query))
+    if filters.get("brand"):
+        item_query_conditions.append(item.brand == filters.get("brand"))
 
-	items = qb.from_(item).select(item.name).where(Criterion.all(item_query_conditions)).run()
-	return items
+    items = (
+        qb.from_(item)
+        .select(item.name)
+        .where(Criterion.all(item_query_conditions))
+        .run()
+    )
+    return items
 
 
 def get_item_details():
-	item_details = {}
-	for d in frappe.db.sql("""SELECT `name`, `item_group`, `brand` FROM `tabItem`""", as_dict=1):
-		item_details.setdefault(d.name, d)
+    item_details = {}
+    for d in frappe.db.sql(
+        """SELECT `name`, `item_group`, `brand` FROM `tabItem`""", as_dict=1
+    ):
+        item_details.setdefault(d.name, d)
 
-	return item_details
+    return item_details
+
+
+# fmt = [
+#     "SI-01-2026-00009",
+#     "Brilliance Electric Ltd",
+#     "Kenya",
+#     "Industrial Area Sales - MG",
+#     datetime.date(2026, 1, 6),
+#     "Island Slab Grey Sparkle (2400*1000*20mm)",
+#     "Products",
+#     None,
+#     1.0,
+#     12000.0,
+#     "Sofia Nyambura",
+#     100.0,
+#     1.0,
+#     12000.0,
+#     "KES",
+# ]
+
+
+# data = {
+#     "indent": 1,
+#     "sales_order": "SO-01-2026-00002",
+#     "customer": "Barago construction and suppliers Ltd",
+#     "territory": "Kenya",
+#     "warehouse": "Industrial Area Sales - MG",
+#     "posting_date": datetime.date(2026, 1, 2),
+#     "item_code": "Kenyan Black Granite Slab (2400*600*20mm)",
+#     "item_group": "Products",
+#     "brand": None,
+#     "stock_qty": 4.0,
+#     "base_net_amount": 25862.08,
+#     "sales_person": "Sofia Nyambura",
+#     "allocated_percentage": 100.0,
+#     "contribution": 4.0,
+#     "contribution_amt": 25862.08,
+#     "company_currency": None,
+#     "currency": "KES",
+# }

--- a/csf_ke/csf_ke/report/sales_person_wise_transaction_summary_enhanced/sales_person_wise_transaction_summary_enhanced.py
+++ b/csf_ke/csf_ke/report/sales_person_wise_transaction_summary_enhanced/sales_person_wise_transaction_summary_enhanced.py
@@ -11,218 +11,217 @@ from frappe.query_builder import Criterion
 
 
 def execute(filters=None):
-    if not filters:
-        filters = {}
+	if not filters:
+		filters = {}
 
-    columns = get_columns(filters)
-    entries = get_entries(filters)
-    item_details = get_item_details()
-    data = []
+	columns = get_columns(filters)
+	entries = get_entries(filters)
+	item_details = get_item_details()
+	data = []
 
-    company_currency = get_company_currency(filters.get("company"))
+	company_currency = get_company_currency(filters.get("company"))
 
-    grouped = OrderedDict()
+	grouped = OrderedDict()
 
-    for d in entries:
-        row = frappe._dict()
-        grouped.setdefault(
-            d.duration,
-            [
-                frappe._dict(
-                    duration=d.duration,
-                    indent=0,
-                    qty=None,
-                    amount=None,
-                    contribution=None,
-                    contribution_qty=None,
-                    contribution_amt=None,
-                )
-            ],
-        ).append(
-            row.update(
-                {
-                    "indent": 1,
-                }
-            )
-        )
+	for d in entries:
+		row = frappe._dict()
+		grouped.setdefault(
+			d.duration,
+			[
+				frappe._dict(
+					duration=d.duration,
+					indent=0,
+					qty=None,
+					amount=None,
+					contribution=None,
+					contribution_qty=None,
+					contribution_amt=None,
+				)
+			],
+		).append(
+			row.update(
+				{
+					"indent": 1,
+				}
+			)
+		)
 
-        if d.stock_qty > 0 or filters.get("show_return_entries", 0):
-            row[frappe.scrub(filters["doc_type"])] = d.name
-            row.customer = d.customer
-            row.territory = d.territory
-            row.warehouse = d.warehouse
-            row.posting_date = d.posting_date
-            row.item_code = d.item_code
-            row.item_group = item_details.get(d.item_code, {}).get("item_group")
-            row.brand = item_details.get(d.item_code, {}).get("brand")
-            row.qty = d.stock_qty
-            row.amount = d.base_net_amount
-            row.sales_person = d.sales_person
-            row.contribution = d.allocated_percentage
-            row.contribution_qty = d.stock_qty * d.allocated_percentage / 100
-            row.contribution_amt = d.contribution_amt
-            row.currency = company_currency
+		if d.stock_qty > 0 or filters.get("show_return_entries", 0):
+			row[frappe.scrub(filters["doc_type"])] = d.name
+			row.customer = d.customer
+			row.territory = d.territory
+			row.warehouse = d.warehouse
+			row.posting_date = d.posting_date
+			row.item_code = d.item_code
+			row.item_group = item_details.get(d.item_code, {}).get("item_group")
+			row.brand = item_details.get(d.item_code, {}).get("brand")
+			row.qty = d.stock_qty
+			row.amount = d.base_net_amount
+			row.sales_person = d.sales_person
+			row.contribution = d.allocated_percentage
+			row.contribution_qty = d.stock_qty * d.allocated_percentage / 100
+			row.contribution_amt = d.contribution_amt
+			row.currency = company_currency
 
-    for group in grouped.values():
-        data.extend(group)
+	for group in grouped.values():
+		data.extend(group)
 
-    return columns, data
+	return columns, data
 
 
 def get_columns(filters):
-    if not filters.get("doc_type"):
-        msgprint(_("Please select the document type first"), raise_exception=True)
+	if not filters.get("doc_type"):
+		msgprint(_("Please select the document type first"), raise_exception=True)
 
-    columns = [
-        {
-            "label": _(filters["duration"][:-2]),
-            "fieldname": "duration",
-            "fieldtype": "Data",
-        },
-        {
-            "label": _(filters["doc_type"]),
-            "options": filters["doc_type"],
-            "fieldname": frappe.scrub(filters["doc_type"]),
-            "fieldtype": "Link",
-            "width": 140,
-        },
-        {
-            "label": _("Customer"),
-            "options": "Customer",
-            "fieldname": "customer",
-            "fieldtype": "Link",
-            "width": 140,
-        },
-        {
-            "label": _("Territory"),
-            "options": "Territory",
-            "fieldname": "territory",
-            "fieldtype": "Link",
-            "width": 140,
-        },
-        {
-            "label": _("Warehouse"),
-            "options": "Warehouse",
-            "fieldname": "warehouse",
-            "fieldtype": "Link",
-            "width": 140,
-        },
-        {
-            "label": _("Posting Date"),
-            "fieldname": "posting_date",
-            "fieldtype": "Date",
-            "width": 140,
-        },
-        {
-            "label": _("Item Code"),
-            "options": "Item",
-            "fieldname": "item_code",
-            "fieldtype": "Link",
-            "width": 140,
-        },
-        {
-            "label": _("Item Group"),
-            "options": "Item Group",
-            "fieldname": "item_group",
-            "fieldtype": "Link",
-            "width": 140,
-        },
-        {
-            "label": _("Brand"),
-            "options": "Brand",
-            "fieldname": "brand",
-            "fieldtype": "Link",
-            "width": 140,
-        },
-        {
-            "label": _("SO Total Qty"),
-            "fieldname": "qty",
-            "fieldtype": "Float",
-            "width": 140,
-        },
-        {
-            "label": _("Amount"),
-            "options": "currency",
-            "fieldname": "amount",
-            "fieldtype": "Currency",
-            "width": 140,
-        },
-        {
-            "label": _("Sales Person"),
-            "options": "Sales Person",
-            "fieldname": "sales_person",
-            "fieldtype": "Link",
-            "width": 140,
-        },
-        {
-            "label": _("Contribution %"),
-            "fieldname": "contribution",
-            "fieldtype": "Float",
-            "width": 140,
-        },
-        {
-            "label": _("Contribution Qty"),
-            "fieldname": "contribution_qty",
-            "fieldtype": "Float",
-            "width": 140,
-        },
-        {
-            "label": _("Contribution Amount"),
-            "options": "currency",
-            "fieldname": "contribution_amt",
-            "fieldtype": "Currency",
-            "width": 140,
-        },
-        {
-            "label": _("Currency"),
-            "options": "Currency",
-            "fieldname": "currency",
-            "fieldtype": "Link",
-            "hidden": 1,
-        },
-    ]
+	columns = [
+		{
+			"label": _(filters["duration"][:-2]),
+			"fieldname": "duration",
+			"fieldtype": "Data",
+		},
+		{
+			"label": _(filters["doc_type"]),
+			"options": filters["doc_type"],
+			"fieldname": frappe.scrub(filters["doc_type"]),
+			"fieldtype": "Link",
+			"width": 140,
+		},
+		{
+			"label": _("Customer"),
+			"options": "Customer",
+			"fieldname": "customer",
+			"fieldtype": "Link",
+			"width": 140,
+		},
+		{
+			"label": _("Territory"),
+			"options": "Territory",
+			"fieldname": "territory",
+			"fieldtype": "Link",
+			"width": 140,
+		},
+		{
+			"label": _("Warehouse"),
+			"options": "Warehouse",
+			"fieldname": "warehouse",
+			"fieldtype": "Link",
+			"width": 140,
+		},
+		{
+			"label": _("Posting Date"),
+			"fieldname": "posting_date",
+			"fieldtype": "Date",
+			"width": 140,
+		},
+		{
+			"label": _("Item Code"),
+			"options": "Item",
+			"fieldname": "item_code",
+			"fieldtype": "Link",
+			"width": 140,
+		},
+		{
+			"label": _("Item Group"),
+			"options": "Item Group",
+			"fieldname": "item_group",
+			"fieldtype": "Link",
+			"width": 140,
+		},
+		{
+			"label": _("Brand"),
+			"options": "Brand",
+			"fieldname": "brand",
+			"fieldtype": "Link",
+			"width": 140,
+		},
+		{
+			"label": _("SO Total Qty"),
+			"fieldname": "qty",
+			"fieldtype": "Float",
+			"width": 140,
+		},
+		{
+			"label": _("Amount"),
+			"options": "currency",
+			"fieldname": "amount",
+			"fieldtype": "Currency",
+			"width": 140,
+		},
+		{
+			"label": _("Sales Person"),
+			"options": "Sales Person",
+			"fieldname": "sales_person",
+			"fieldtype": "Link",
+			"width": 140,
+		},
+		{
+			"label": _("Contribution %"),
+			"fieldname": "contribution",
+			"fieldtype": "Float",
+			"width": 140,
+		},
+		{
+			"label": _("Contribution Qty"),
+			"fieldname": "contribution_qty",
+			"fieldtype": "Float",
+			"width": 140,
+		},
+		{
+			"label": _("Contribution Amount"),
+			"options": "currency",
+			"fieldname": "contribution_amt",
+			"fieldtype": "Currency",
+			"width": 140,
+		},
+		{
+			"label": _("Currency"),
+			"options": "Currency",
+			"fieldname": "currency",
+			"fieldtype": "Link",
+			"hidden": 1,
+		},
+	]
 
-    return columns
+	return columns
 
 
 def get_duration_clause(filters):
-    duration_clause = None
-    if filters["duration"] == "Monthly":
-        duration_clause = "MONTH(dt.{}) as duration"
+	duration_clause = None
+	if filters["duration"] == "Monthly":
+		duration_clause = "MONTH(dt.{}) as duration"
 
-    elif filters["duration"] == "Quarterly":
-        duration_clause = "QUARTER(dt.{}) as duration"
+	elif filters["duration"] == "Quarterly":
+		duration_clause = "QUARTER(dt.{}) as duration"
 
-    elif filters["duration"] == "Yearly":
-        duration_clause = "YEAR(dt.{}) as duration"
+	elif filters["duration"] == "Yearly":
+		duration_clause = "YEAR(dt.{}) as duration"
 
-    elif filters["duration"] == "Weekly":
-        duration_clause = "WEEK(dt.{}) as duration"
+	elif filters["duration"] == "Weekly":
+		duration_clause = "WEEK(dt.{}) as duration"
 
-    if duration_clause:
-        if filters["doc_type"] in ("Sales Invoice", "Delivery Note"):
-            duration_clause = duration_clause.format("posting_date")
+	if duration_clause:
+		if filters["doc_type"] in ("Sales Invoice", "Delivery Note"):
+			duration_clause = duration_clause.format("posting_date")
 
-        else:
-            duration_clause = duration_clause.format("transaction_date")
+		else:
+			duration_clause = duration_clause.format("transaction_date")
 
-    return duration_clause
+	return duration_clause
 
 
 def get_entries(filters):
-    date_field = (
-        filters["doc_type"] == "Sales Order" and "transaction_date"
-    ) or "posting_date"
-    if filters["doc_type"] == "Sales Order":
-        qty_field = "delivered_qty"
-    else:
-        qty_field = "qty"
+	date_field = (filters["doc_type"] == "Sales Order" and "transaction_date") or "posting_date"
 
-    conditions, values = get_conditions(filters, date_field)
-    duration_clause = get_duration_clause(filters)
+	if filters["doc_type"] == "Sales Order":
+		qty_field = "delivered_qty"
+	else:
+		qty_field = "qty"
 
-    entries = frappe.db.sql(
-        """
+	conditions, values = get_conditions(filters, date_field)
+	duration_clause = get_duration_clause(filters)
+
+	entries = frappe.db.sql(
+		"""
         SELECT
             dt.name, dt.customer, dt.territory, dt.{} as posting_date, dt_item.item_code,
             st.sales_person, st.allocated_percentage, dt_item.warehouse,
@@ -245,136 +244,87 @@ def get_entries(filters):
             and dt.docstatus = 1 {}
         ORDER BY st.sales_person, dt.name desc
         """.format(
-            date_field,
-            qty_field,
-            qty_field,
-            qty_field,
-            duration_clause,
-            filters["doc_type"],
-            filters["doc_type"],
-            "%s",
-            conditions,
-        ),
-        tuple([filters["doc_type"], *values]),
-        as_dict=1,
-    )
+			date_field,
+			qty_field,
+			qty_field,
+			qty_field,
+			duration_clause,
+			filters["doc_type"],
+			filters["doc_type"],
+			"%s",
+			conditions,
+		),
+		tuple([filters["doc_type"], *values]),
+		as_dict=1,
+	)
 
-    return entries
+	return entries
 
 
 def get_conditions(filters, date_field):
-    conditions = [""]
-    values = []
+	conditions = [""]
+	values = []
 
-    for field in ["company", "customer", "territory"]:
-        if filters.get(field):
-            conditions.append(f"dt.{field}=%s")
-            values.append(filters[field])
+	for field in ["company", "customer", "territory"]:
+		if filters.get(field):
+			conditions.append(f"dt.{field}=%s")
+			values.append(filters[field])
 
-    if filters.get("sales_person"):
-        lft, rgt = frappe.get_value(
-            "Sales Person", filters.get("sales_person"), ["lft", "rgt"]
-        )
-        conditions.append(
-            f"exists(select name from `tabSales Person` where lft >= {lft} and rgt <= {rgt} and name=st.sales_person)"
-        )
+	if filters.get("sales_person"):
+		lft, rgt = frappe.get_value("Sales Person", filters.get("sales_person"), ["lft", "rgt"])
+		conditions.append(
+			f"exists(select name from `tabSales Person` where lft >= {lft} and rgt <= {rgt} and name=st.sales_person)"
+		)
 
-    if filters.get("from_date"):
-        conditions.append(f"dt.{date_field}>=%s")
-        values.append(filters["from_date"])
+	if filters.get("from_date"):
+		conditions.append(f"dt.{date_field}>=%s")
+		values.append(filters["from_date"])
 
-    if filters.get("to_date"):
-        conditions.append(f"dt.{date_field}<=%s")
-        values.append(filters["to_date"])
+	if filters.get("to_date"):
+		conditions.append(f"dt.{date_field}<=%s")
+		values.append(filters["to_date"])
 
-    items = get_items(filters)
-    if items:
-        placeholders = ", ".join(["%s"] * len(items))
-        conditions.append(f"dt_item.item_code in ({placeholders})")
-        values += items
-    else:
-        # return empty result, if no items are fetched after filtering on 'item group' and 'brand'
-        conditions.append("dt_item.item_code = Null")
+	items = get_items(filters)
+	if items:
+		placeholders = ", ".join(["%s"] * len(items))
+		conditions.append(f"dt_item.item_code in ({placeholders})")
+		values += items
+	else:
+		# return empty result, if no items are fetched after filtering on 'item group' and 'brand'
+		conditions.append("dt_item.item_code = Null")
 
-    return " and ".join(conditions), values
+	return " and ".join(conditions), values
 
 
 def get_items(filters):
-    item = qb.DocType("Item")
+	item = qb.DocType("Item")
 
-    item_query_conditions = []
-    if filters.get("item_group"):
-        # Handle 'Parent' nodes as well.
-        item_group = qb.DocType("Item Group")
-        lft, rgt = frappe.db.get_all(
-            "Item Group",
-            filters={"name": filters.get("item_group")},
-            fields=["lft", "rgt"],
-            as_list=True,
-        )[0]
-        item_group_query = (
-            qb.from_(item_group)
-            .select(item_group.name)
-            .where((item_group.lft >= lft) & (item_group.rgt <= rgt))
-        )
-        item_query_conditions.append(item.item_group.isin(item_group_query))
-    if filters.get("brand"):
-        item_query_conditions.append(item.brand == filters.get("brand"))
+	item_query_conditions = []
+	if filters.get("item_group"):
+		# Handle 'Parent' nodes as well.
+		item_group = qb.DocType("Item Group")
+		lft, rgt = frappe.db.get_all(
+			"Item Group",
+			filters={"name": filters.get("item_group")},
+			fields=["lft", "rgt"],
+			as_list=True,
+		)[0]
+		item_group_query = (
+			qb.from_(item_group)
+			.select(item_group.name)
+			.where((item_group.lft >= lft) & (item_group.rgt <= rgt))
+		)
+		item_query_conditions.append(item.item_group.isin(item_group_query))
+	if filters.get("brand"):
+		item_query_conditions.append(item.brand == filters.get("brand"))
 
-    items = (
-        qb.from_(item)
-        .select(item.name)
-        .where(Criterion.all(item_query_conditions))
-        .run()
-    )
-    return items
+	items = qb.from_(item).select(item.name).where(Criterion.all(item_query_conditions)).run()
+	return items
 
 
 def get_item_details():
-    item_details = {}
-    for d in frappe.db.sql(
-        """SELECT `name`, `item_group`, `brand` FROM `tabItem`""", as_dict=1
-    ):
-        item_details.setdefault(d.name, d)
+	item_details = {}
+	for d in frappe.db.sql("""SELECT `name`, `item_group`, `brand` FROM `tabItem`""", as_dict=1):
+		item_details.setdefault(d.name, d)
 
-    return item_details
-
-
-# fmt = [
-#     "SI-01-2026-00009",
-#     "Brilliance Electric Ltd",
-#     "Kenya",
-#     "Industrial Area Sales - MG",
-#     datetime.date(2026, 1, 6),
-#     "Island Slab Grey Sparkle (2400*1000*20mm)",
-#     "Products",
-#     None,
-#     1.0,
-#     12000.0,
-#     "Sofia Nyambura",
-#     100.0,
-#     1.0,
-#     12000.0,
-#     "KES",
-# ]
-
-
-# data = {
-#     "indent": 1,
-#     "sales_order": "SO-01-2026-00002",
-#     "customer": "Barago construction and suppliers Ltd",
-#     "territory": "Kenya",
-#     "warehouse": "Industrial Area Sales - MG",
-#     "posting_date": datetime.date(2026, 1, 2),
-#     "item_code": "Kenyan Black Granite Slab (2400*600*20mm)",
-#     "item_group": "Products",
-#     "brand": None,
-#     "stock_qty": 4.0,
-#     "base_net_amount": 25862.08,
-#     "sales_person": "Sofia Nyambura",
-#     "allocated_percentage": 100.0,
-#     "contribution": 4.0,
-#     "contribution_amt": 25862.08,
-#     "company_currency": None,
-#     "currency": "KES",
-# }
+	return item_details

--- a/csf_ke/csf_ke/utils/tax_report.py
+++ b/csf_ke/csf_ke/utils/tax_report.py
@@ -1,0 +1,142 @@
+from abc import ABC, abstractmethod
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+
+class TaxReport(ABC):
+	def __init__(self):
+		self.registered_suppliers_total_purchases = 0.0
+		self.registered_suppliers_total_vat = 0.0
+		self.unregistered_suppliers_total_purchases = 0.0
+		self.unregistered_suppliers_total_vat = 0.0
+		self.currency = None
+
+	@abstractmethod
+	def get_columns(self):
+		"""Return the report column definitions (names, labels, types)"""
+
+	@abstractmethod
+	def get_report_summary(self):
+		"""Return the report summary"""
+
+	def get_data(self, invoice_type):
+		data = []
+		invoice_data = self.get_invoice_data(invoice_type)
+		if invoice_data:
+			data = self.process_invoice_data(invoice_data, invoice_type)
+		return data
+
+	def get_invoice_data(self, invoice_type):
+		INV = (
+			frappe.qb.DocType("Sales Invoice")
+			if invoice_type == "sales"
+			else frappe.qb.DocType("Purchase Invoice")
+		)
+		INVI = (
+			frappe.qb.DocType("Sales Invoice Item")
+			if invoice_type == "sales"
+			else frappe.qb.DocType("Purchase Invoice Item")
+		)
+		TD = frappe.qb.DocType("Item Wise Tax Detail")
+
+		query = (
+			frappe.qb.from_(TD)
+			.inner_join(INV)
+			.on(TD.parent == INV.name)
+			.inner_join(INVI)
+			.on((INVI.parent == INV.name) & (INVI.name == TD.item_row))
+			.select(
+				INV.supplier if invoice_type == "purchase" else INV.customer,
+				INV.supplier_name if invoice_type == "purchase" else INV.customer_name,
+				INV.tax_id,
+				INV.name.as_("invoice_number"),
+				INV.posting_date.as_("invoice_date"),
+				INV.return_against,
+				INV.etr_invoice_number,
+				TD.item_row,
+				TD.amount,
+				TD.rate,
+				TD.taxable_amount,
+			)
+			.where(INV.docstatus == 1)
+			# .where(TD.rate != 0)
+		)
+
+		if invoice_type == "purchase":
+			query = query.select(
+				INV.bill_no.as_("supplier_invoice_no"),
+				INV.bill_date.as_("supplier_invoice_date"),
+			)
+
+		if self.filters.get("company"):
+			query = query.where(INV.company == self.filters.get("company"))
+
+		if self.filters.get("from_date"):
+			query = query.where(INV.posting_date >= self.filters.get("from_date"))
+
+		if self.filters.get("to_date"):
+			query = query.where(INV.posting_date <= self.filters.get("to_date"))
+
+		if self.filters.get("item_tax_template"):
+			query = query.where(INVI.item_tax_template == self.filters.get("item_tax_template"))
+
+		if self.filters.get("taxes_and_charges_template"):
+			query = query.where(INV.taxes_and_charges == self.filters.get("taxes_and_charges_template"))
+
+		if self.filters.get("is_return"):
+			query = query.where(INV.is_return == self.filters.get("is_return"))
+
+		return query.run(as_dict=True)
+
+	def process_invoice_data(self, invoice_data, invoice_type):
+		self.currency = frappe.db.get_value("Company", self.filters.get("company"), "default_currency")
+		party_field = "supplier" if invoice_type == "purchase" else "customer"
+		party_name_field = "supplier_name" if invoice_type == "purchase" else "customer_name"
+
+		invoice_map = {}
+		seen_items = {}
+
+		for row in invoice_data:
+			invoice_number = row.get("invoice_number")
+			item_row = row.get("item_row")
+
+			if invoice_number not in invoice_map:
+				invoice_map[invoice_number] = {
+					"party": row.get(party_field),
+					"party_name": row.get(party_name_field),
+					"tax_id": row.get("tax_id"),
+					"invoice_number": invoice_number,
+					"invoice_date": row.get("invoice_date"),
+					"return_against": row.get("return_against"),
+					"supplier_invoice_no": row.get("supplier_invoice_no"),
+					"supplier_invoice_date": row.get("supplier_invoice_date"),
+					"etr_invoice_number": row.get("etr_invoice_number"),
+					"taxable_amount": 0.0,
+					"vat_amount": 0.0,
+					"currency": self.currency,
+				}
+				seen_items[invoice_number] = set()
+
+			invoice_map[invoice_number]["vat_amount"] += flt(row.get("amount", 0))
+
+			if party_field == "supplier":
+				if row.get("tax_id"):
+					self.registered_suppliers_total_vat += flt(row.get("amount", 0))
+				else:
+					self.unregistered_suppliers_total_vat += flt(row.get("amount", 0))
+
+			# Taxable amount is per item; only count it once when an item has
+			# multiple tax rows (e.g. VAT + another charge on the same base).
+			if item_row not in seen_items[invoice_number] and not (row.get("amount")) < 0:
+				invoice_map[invoice_number]["taxable_amount"] += flt(row.get("taxable_amount", 0))
+				seen_items[invoice_number].add(item_row)
+
+				if party_field == "supplier":
+					if row.get("tax_id"):
+						self.registered_suppliers_total_purchases += flt(row.get("taxable_amount", 0))
+					else:
+						self.unregistered_suppliers_total_purchases += flt(row.get("taxable_amount", 0))
+
+		return list(invoice_map.values())

--- a/csf_ke/csf_ke/utils/tax_report.py
+++ b/csf_ke/csf_ke/utils/tax_report.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections import defaultdict
 
 import frappe
 from frappe import _
@@ -26,19 +27,15 @@ class TaxReport(ABC):
 		invoice_data = self.get_invoice_data(invoice_type)
 		if invoice_data:
 			data = self.process_invoice_data(invoice_data, invoice_type)
+			if self.filters.get("accounting_dimension") and data:
+				data = self.group_by_dimension(data)
 		return data
 
 	def get_invoice_data(self, invoice_type):
-		INV = (
-			frappe.qb.DocType("Sales Invoice")
-			if invoice_type == "sales"
-			else frappe.qb.DocType("Purchase Invoice")
-		)
-		INVI = (
-			frappe.qb.DocType("Sales Invoice Item")
-			if invoice_type == "sales"
-			else frappe.qb.DocType("Purchase Invoice Item")
-		)
+		invoice_doctype = "Sales Invoice" if invoice_type == "sales" else "Purchase Invoice"
+		item_doctype = f"{invoice_doctype} Item"
+		INV = frappe.qb.DocType(invoice_doctype)
+		INVI = frappe.qb.DocType(item_doctype)
 		TD = frappe.qb.DocType("Item Wise Tax Detail")
 
 		query = (
@@ -70,6 +67,10 @@ class TaxReport(ABC):
 				INV.bill_date.as_("supplier_invoice_date"),
 			)
 
+		# TODO: handle invoice_type = sales
+
+		query = self._select_accounting_dimension(query, INV, invoice_doctype)
+
 		if self.filters.get("company"):
 			query = query.where(INV.company == self.filters.get("company"))
 
@@ -90,13 +91,26 @@ class TaxReport(ABC):
 
 		return query.run(as_dict=True)
 
+	def _select_accounting_dimension(self, query, INV, invoice_doctype):
+		accounting_dimension = self.filters.get("accounting_dimension")
+		if not accounting_dimension:
+			return query
+
+		fieldname = frappe.scrub(accounting_dimension)
+		if frappe.get_meta(invoice_doctype).has_field(fieldname):
+			return query.select(getattr(INV, fieldname).as_("accounting_dimension_value"))
+
+		return query
+
 	def process_invoice_data(self, invoice_data, invoice_type):
 		self.currency = frappe.db.get_value("Company", self.filters.get("company"), "default_currency")
 		party_field = "supplier" if invoice_type == "purchase" else "customer"
 		party_name_field = "supplier_name" if invoice_type == "purchase" else "customer_name"
+		group_by_dimension = bool(self.filters.get("accounting_dimension"))
 
 		invoice_map = {}
 		seen_items = {}
+		return_against_map = {}
 
 		for row in invoice_data:
 			invoice_number = row.get("invoice_number")
@@ -117,6 +131,16 @@ class TaxReport(ABC):
 					"vat_amount": 0.0,
 					"currency": self.currency,
 				}
+
+				if row.get("return_against"):
+					return_against_map[row.get("return_against")] = {
+						"invoice_number": row.get("return_against"),
+					}
+
+				if group_by_dimension:
+					invoice_map[invoice_number]["accounting_dimension_value"] = row.get(
+						"accounting_dimension_value"
+					)
 				seen_items[invoice_number] = set()
 
 			invoice_map[invoice_number]["vat_amount"] += flt(row.get("amount", 0))
@@ -129,7 +153,10 @@ class TaxReport(ABC):
 
 			# Taxable amount is per item; only count it once when an item has
 			# multiple tax rows (e.g. VAT + another charge on the same base).
-			if item_row not in seen_items[invoice_number] and not (row.get("amount")) < 0:
+			if (
+				item_row not in seen_items[invoice_number]
+				# and not (row.get("amount")) == 0
+			):
 				invoice_map[invoice_number]["taxable_amount"] += flt(row.get("taxable_amount", 0))
 				seen_items[invoice_number].add(item_row)
 
@@ -139,4 +166,70 @@ class TaxReport(ABC):
 					else:
 						self.unregistered_suppliers_total_purchases += flt(row.get("taxable_amount", 0))
 
+		if invoice_type == "purchase":
+			INV = frappe.qb.DocType("Purchase Invoice")
+			if return_against_map:
+				query = (
+					frappe.qb.from_(INV)
+					.select(
+						INV.name,
+						INV.etr_invoice_number,
+						INV.bill_date,
+						INV.posting_date,
+					)
+					.where(INV.name.isin(list(return_against_map.keys())))
+					.where(INV.etr_invoice_number.isnotnull())
+				)
+				data = query.run(as_dict=True)
+				for row in data:
+					return_against_map[row.name] = {
+						"original_cu_invoice_number": row.etr_invoice_number,
+						"original_cu_invoice_date": row.get("bill_date", row.get("posting_date")),
+					}
+
+			if invoice_map and return_against_map:
+				for __, invoice_data in invoice_map.items():
+					if (
+						invoice_data.get("return_against")
+						and return_against_map.get(invoice_data.get("return_against"))
+						and return_against_map.get(invoice_data.get("return_against")).get(
+							"original_cu_invoice_number"
+						)
+					):
+						invoice_data["original_cu_invoice_number"] = return_against_map[
+							invoice_data.get("return_against")
+						].get("original_cu_invoice_number")
+						invoice_data["original_cu_invoice_date"] = return_against_map[
+							invoice_data.get("return_against")
+						].get("original_cu_invoice_date")
+
+		# TODO: handle invoice_type = sales
+
 		return list(invoice_map.values())
+
+	def group_by_dimension(self, data):
+		"""Group rows by accounting dimension with header totals per group."""
+		grouped_data = defaultdict(list)
+		for row in data:
+			dimension_value = row.get("accounting_dimension_value") or _("No Dimension")
+			# row["accounting_dimension_value"] = dimension_value
+			grouped_data[dimension_value].append(row)
+
+		final_data = []
+		for dimension_value in sorted(grouped_data.keys()):
+			group_rows = grouped_data[dimension_value]
+			final_data.append(
+				{
+					"accounting_dimension_value": dimension_value,
+					"party_name": None,
+					"taxable_amount": sum(flt(row.get("taxable_amount")) for row in group_rows),
+					"vat_amount": sum(flt(row.get("vat_amount")) for row in group_rows),
+					"currency": self.currency,
+					"is_group_header": True,
+				}
+			)
+			for row in group_rows:
+				row["indent"] = 1
+				final_data.append(row)
+
+		return final_data


### PR DESCRIPTION
- Rebuild on Item Wise Tax Detail via a
shared TaxReport base so those invoices are included, and so purchase
(and future sales) reports can share taxable/VAT aggregation and
registered vs unregistered supplier summaries.

- Simplify the purchase report UI: checkbox for is_return, Item Tax
Template / Purchase Taxes and Charges Template filters driven by
Accounts Settings

- Prevent creation of an Error Log on every purchase submit when no price margins are configured