### PR TITLE
Rename 'Closing Stock Balance' to 'Stock Closing Balance' due to doctype rename in v16

### DIFF
--- a/csf_ke/csf_ke/report/stock_movement/stock_movement.py
+++ b/csf_ke/csf_ke/report/stock_movement/stock_movement.py
@@ -88,7 +88,7 @@ class StockBalanceReport:
 			return
 
 		self.start_from = add_days(closing_balance[0].to_date, 1)
-		res = frappe.get_doc("Closing Stock Balance", closing_balance[0].name).get_prepared_data()
+		res = frappe.get_doc("Stock Closing Balance", closing_balance[0].name).get_prepared_data()
 
 		for entry in res.data:
 			entry = frappe._dict(entry)
@@ -310,7 +310,7 @@ class StockBalanceReport:
 		if self.filters.get("ignore_closing_balance"):
 			return []
 
-		table = frappe.qb.DocType("Closing Stock Balance")
+		table = frappe.qb.DocType("Stock Closing Balance")
 
 		query = (
 			frappe.qb.from_(table)


### PR DESCRIPTION
This pull request updates references to the "Closing Stock Balance" DocType in the `stock_movement.py` report to use "Stock Closing Balance" instead. This improves consistency and ensures the code interacts with the correct DocType throughout the report logic.

**DocType reference updates:**

* Updated the `prepare_opening_data_from_closing_balance` method to fetch data from the `Stock Closing Balance` DocType instead of `Closing Stock Balance`.
* Updated the `get_closing_balance` method to use the `Stock Closing Balance` DocType in database queries per doctype rename in V16